### PR TITLE
Feature/realtime io

### DIFF
--- a/include/ur_modern_driver/robot_state_RT.h
+++ b/include/ur_modern_driver/robot_state_RT.h
@@ -60,7 +60,6 @@ private:
 	double i_robot_; //Masterboard: Robot current
 	std::vector<double> v_actual_; //Actual joint voltages
     std::vector<bool> digital_output_bits_; //Digital outputs (similar to digital input bits)
-    double program_state_; //Program state
 
 	std::mutex val_lock_; // Locks the variables while unpack parses data;
 

--- a/include/ur_modern_driver/robot_state_RT.h
+++ b/include/ur_modern_driver/robot_state_RT.h
@@ -105,7 +105,6 @@ public:
 	double getVMain();
 	double getVRobot();
 	double getIRobot();
-    double getProgramState();
 
 	void setVersion(double ver);
 

--- a/include/ur_modern_driver/robot_state_RT.h
+++ b/include/ur_modern_driver/robot_state_RT.h
@@ -46,8 +46,8 @@ private:
 	std::vector<double> tcp_force_; //Generalised forces in the TC
 	std::vector<double> tool_vector_target_; //Target Cartesian coordinates of the tool: (x,y,z,rx,ry,rz), where rx, ry and rz is a rotation vector representation of the tool orientation
 	std::vector<double> tcp_speed_target_; //Target speed of the tool given in Cartesian coordinates
-	std::vector<bool> digital_input_bits_; //Current state of the digital inputs. NOTE: these are bits encoded as int64_t, e.g. a value of 5 corresponds to bit 0 and bit 2 set high
-	std::vector<double> motor_temperatures_; //Temperature of each joint in degrees celsius
+    std::vector<bool> digital_input_bits_; //Current state of the digital inputs. NOTE: these are bits encoded as int64_t, e.g. a value of 5 corresponds to bit 0 and bit 2 set high
+    std::vector<double> motor_temperatures_; //Temperature of each joint in degrees celsius
 	double controller_timer_; //Controller realtime thread execution time
 	double robot_mode_; //Robot mode
 	std::vector<double> joint_modes_; //Joint control modes
@@ -59,6 +59,8 @@ private:
 	double v_robot_; //Matorborad: Robot voltage (48V)
 	double i_robot_; //Masterboard: Robot current
 	std::vector<double> v_actual_; //Actual joint voltages
+    std::vector<bool> digital_output_bits_; //Digital outputs (similar to digital input bits)
+    double program_state_; //Program state
 
 	std::mutex val_lock_; // Locks the variables while unpack parses data;
 
@@ -68,7 +70,7 @@ private:
 
 	std::vector<double> unpackVector(uint8_t * buf, int start_index,
 			int nr_of_vals);
-	std::vector<bool> unpackDigitalInputBits(int64_t data);
+    std::vector<bool> unpackDigitalBits(int64_t data);
 	double ntohd(uint64_t nf);
 
 public:
@@ -91,6 +93,7 @@ public:
 	std::vector<double> getToolVectorTarget();
 	std::vector<double> getTcpSpeedTarget();
 	std::vector<bool> getDigitalInputBits();
+    std::vector<bool> getDigitalOutputBits();
 	std::vector<double> getMotorTemperatures();
 	double getControllerTimer();
 	double getRobotMode();
@@ -102,6 +105,7 @@ public:
 	double getVMain();
 	double getVRobot();
 	double getIRobot();
+    double getProgramState();
 
 	void setVersion(double ver);
 

--- a/src/robot_state_RT.cpp
+++ b/src/robot_state_RT.cpp
@@ -316,13 +316,6 @@ std::vector<double> RobotStateRT::getVActual() {
 	val_lock_.unlock();
 	return ret;
 }
-double RobotStateRT::getProgramState() {
-    double ret;
-    val_lock_.lock();
-    ret = program_state_;
-    val_lock_.unlock();
-    return ret;
-}
 void RobotStateRT::unpack(uint8_t * buf) {
     int64_t digital_input_bits;
     int64_t digital_ouput_bits;

--- a/src/ur_ros_wrapper.cpp
+++ b/src/ur_ros_wrapper.cpp
@@ -675,8 +675,8 @@ private:
                     io_msg_rt.digital_out_states.push_back(digi);
                     pin++;
                 }
+                io_pub_rt.publish(io_msg_rt);
             }
-            io_pub_rt.publish(io_msg_rt);
 
 			robot_.rt_interface_->robot_state_->setDataPublished();
 		}

--- a/src/ur_ros_wrapper.cpp
+++ b/src/ur_ros_wrapper.cpp
@@ -669,10 +669,10 @@ private:
                 pin = 0;
                 for (std::vector<bool>::iterator it = dout.begin(); it != dout.end(); ++it)
                 {
-                    ur_msgs::Digital digi;
-                    digi.pin = pin;
-                    digi.state = *it;
-                    io_msg_rt.digital_out_states.push_back(digi);
+                    ur_msgs::Digital digo;
+                    digo.pin = pin;
+                    digo.state = *it;
+                    io_msg_rt.digital_out_states.push_back(digo);
                     pin++;
                 }
                 io_pub_rt.publish(io_msg_rt);


### PR DESCRIPTION
For >v3.2, UR exposes the digital input and output values on the realtime interface (125 Hz). Using these values instead of the 20 Hz interface significantly improves performance.

This unpacks and exposes the digital input and output bits on ROS topic 'ur_driver/io_states_rt'. Note that this is only done if the UR has version 3.2 or later.

See also issue #50.