### PR TITLE
Add arguments to ros_control launchfiles to select loaded controllers.

### DIFF
--- a/launch/ur10_ros_control.launch
+++ b/launch/ur10_ros_control.launch
@@ -10,10 +10,12 @@
   <arg name="limited" default="false"/>
   <arg name="min_payload"  default="0.0"/>
   <arg name="max_payload"  default="3.0"/>
-  <arg name="prefix" default="" />  
+  <arg name="prefix" default="" />
   <arg name="max_velocity" default="10.0"/> <!-- [rad/s] -->
   <arg name="base_frame" default="$(arg prefix)base" />
   <arg name="tool_frame" default="$(arg prefix)tool0_controller" />
+  <arg name="controllers" default="joint_state_controller force_torque_sensor_controller vel_based_pos_traj_controller"/>
+  <arg name="stopped_controllers" default="pos_based_pos_traj_controller"/>
   <!-- robot model -->
   <include file="$(find ur_description)/launch/ur10_upload.launch">
     <arg name="limited" value="$(arg limited)"/>
@@ -38,11 +40,11 @@
 
   <!-- spawn controller manager -->
   <node name="ros_control_controller_spawner" pkg="controller_manager" type="spawner" respawn="false"
-    output="screen" args="joint_state_controller force_torque_sensor_controller vel_based_pos_traj_controller" />
+    output="screen" args="$(arg controllers)" />
 
-  <!-- load other controller --> 
+  <!-- load other controller -->
   <node name="ros_control_controller_manager" pkg="controller_manager" type="controller_manager" respawn="false"
-    output="screen" args="load pos_based_pos_traj_controller" /> 
+    output="screen" args="load $(arg stopped_controllers)" />
 
   <!-- Convert joint states to /tf tranforms -->
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>

--- a/launch/ur3_ros_control.launch
+++ b/launch/ur3_ros_control.launch
@@ -14,6 +14,8 @@
   <arg name="max_velocity" default="10.0"/> <!-- [rad/s] -->
   <arg name="base_frame" default="$(arg prefix)base" />
   <arg name="tool_frame" default="$(arg prefix)tool0_controller" />
+  <arg name="controllers" default="joint_state_controller force_torque_sensor_controller pos_based_pos_traj_controller"/>
+  <arg name="stopped_controllers" default="vel_based_pos_traj_controller"/>
   <!-- robot model -->
   <include file="$(find ur_description)/launch/ur3_upload.launch">
     <arg name="limited" value="$(arg limited)"/>
@@ -38,11 +40,11 @@
 
   <!-- spawn controller manager -->
   <node name="ros_control_controller_spawner" pkg="controller_manager" type="spawner" respawn="false"
-    output="screen" args="joint_state_controller force_torque_sensor_controller pos_based_pos_traj_controller" />
+    output="screen" args="$(arg controllers)" />
 
   <!-- load other controller -->
   <node name="ros_control_controller_manager" pkg="controller_manager" type="controller_manager" respawn="false"
-    output="screen" args="load vel_based_pos_traj_controller" />
+    output="screen" args="load $(arg stopped_controllers)" />
 
   <!-- Convert joint states to /tf tranforms -->
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>

--- a/launch/ur5_ros_control.launch
+++ b/launch/ur5_ros_control.launch
@@ -10,10 +10,12 @@
   <arg name="limited" default="false"/>
   <arg name="min_payload"  default="0.0"/>
   <arg name="max_payload"  default="3.0"/>
-  <arg name="prefix" default="" />  
+  <arg name="prefix" default="" />
   <arg name="max_velocity" default="10.0"/> <!-- [rad/s] -->
   <arg name="base_frame" default="$(arg prefix)base" />
   <arg name="tool_frame" default="$(arg prefix)tool0_controller" />
+  <arg name="controllers" default="joint_state_controller force_torque_sensor_controller vel_based_pos_traj_controller"/>
+  <arg name="stopped_controllers" default="pos_based_pos_traj_controller"/>
   <!-- robot model -->
   <include file="$(find ur_description)/launch/ur5_upload.launch">
     <arg name="limited" value="$(arg limited)"/>
@@ -38,11 +40,11 @@
 
   <!-- spawn controller manager -->
   <node name="ros_control_controller_spawner" pkg="controller_manager" type="spawner" respawn="false"
-    output="screen" args="joint_state_controller force_torque_sensor_controller vel_based_pos_traj_controller" />
+    output="screen" args="$(arg controllers)" />
 
-  <!-- load other controller --> 
+  <!-- load other controller -->
   <node name="ros_control_controller_manager" pkg="controller_manager" type="controller_manager" respawn="false"
-    output="screen" args="load pos_based_pos_traj_controller" /> 
+    output="screen" args="load $(arg stopped_controllers)" />
 
   <!-- Convert joint states to /tf tranforms -->
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>


### PR DESCRIPTION
Since the stability issues seem to affect several users, I think adding launchfile arguments to select which controllers to load/start at launchtime can help. At the very least it will help us give [indications](https://github.com/ThomasTimm/ur_modern_driver/issues/148#issuecomment-344850704) about how to test the same setup with the position interface controllers.

BTW, while doing this, I noticed that the default controllers loaded are not coherent between different launchfiles:
- UR5 & UR10 will launch with the `vel_based_pos_traj_controller` started by default
- UR3 will launch with the `pos_based_pos_traj_controller` started by default

I kept these defaults to avoid breaking other people's setups, but I would favor unifying the default settings somehow.