### PR TITLE
General cleanup of build script and package manifest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ catkin_package(
     ur_hardware_interface
   CATKIN_DEPENDS
     hardware_interface
+    industrial_msgs
     controller_manager
     actionlib
     control_msgs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,19 +3,20 @@ project(ur_modern_driver)
 
 add_definitions( -DROS_BUILD )
 
-find_package(catkin REQUIRED COMPONENTS
-  hardware_interface
-  controller_manager
-  actionlib
-  control_msgs
-  geometry_msgs
-  industrial_msgs
-  roscpp
-  sensor_msgs
-  std_srvs
-  trajectory_msgs
-  ur_msgs
-  tf
+find_package(catkin REQUIRED
+  COMPONENTS
+    actionlib
+    control_msgs
+    controller_manager
+    geometry_msgs
+    hardware_interface
+    industrial_msgs
+    roscpp
+    sensor_msgs
+    std_srvs
+    tf
+    trajectory_msgs
+    ur_msgs
 )
 
 
@@ -25,12 +26,12 @@ catkin_package(
   LIBRARIES
     ur_hardware_interface
   CATKIN_DEPENDS
-    hardware_interface
-    industrial_msgs
-    controller_manager
     actionlib
     control_msgs
+    controller_manager
     geometry_msgs
+    hardware_interface
+    industrial_msgs
     roscpp
     sensor_msgs
     trajectory_msgs
@@ -40,14 +41,14 @@ catkin_package(
 
 # check c++11 / c++0x
 include(CheckCXXCompilerFlag)
-CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
-CHECK_CXX_COMPILER_FLAG("-std=c++0x" COMPILER_SUPPORTS_CXX0X)
+check_cxx_compiler_flag("-std=c++11" COMPILER_SUPPORTS_CXX11)
+check_cxx_compiler_flag("-std=c++0x" COMPILER_SUPPORTS_CXX0X)
 if(COMPILER_SUPPORTS_CXX11)
-    add_compile_options(-std=c++11)
+  add_compile_options(-std=c++11)
 elseif(COMPILER_SUPPORTS_CXX0X)
-    add_compile_options(-std=c++0x)
+  add_compile_options(-std=c++0x)
 else()
-    message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler. Suggested solution: update the pkg build-essential ")
+  message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler. Suggested solution: update the pkg build-essential ")
 endif()
 
 add_compile_options(-Wall)
@@ -56,7 +57,7 @@ add_compile_options(-Wno-unused-parameter)
 
 # support indigo's ros_control - This can be removed upon EOL indigo
 if("${controller_manager_msgs_VERSION}" VERSION_LESS "0.10.0")
-    add_definitions(-DUR_ROS_CONTROL_INTERFACE_OLD_ROS_CONTROL)
+  add_definitions(-DUR_ROS_CONTROL_INTERFACE_OLD_ROS_CONTROL)
 endif()
 
 include_directories(
@@ -66,27 +67,27 @@ include_directories(
 
 # Hardware Interface
 add_library(ur_hardware_interface
-  src/ros/hardware_interface.cpp
-  src/ros/controller.cpp)
+  src/ros/controller.cpp
+  src/ros/hardware_interface.cpp)
 target_link_libraries(ur_hardware_interface ${catkin_LIBRARIES})
 
 
 set(${PROJECT_NAME}_SOURCES
     src/ros/action_server.cpp
+    src/ros/lowbandwidth_trajectory_follower.cpp
     src/ros/mb_publisher.cpp
     src/ros/rt_publisher.cpp
     src/ros/service_stopper.cpp
     src/ros/trajectory_follower.cpp
-    src/ros/lowbandwidth_trajectory_follower.cpp
     src/ros/urscript_handler.cpp
-    src/ur/stream.cpp
-    src/ur/server.cpp
+    src/tcp_socket.cpp
     src/ur/commander.cpp
-    src/ur/robot_mode.cpp
     src/ur/master_board.cpp
-    src/ur/rt_state.cpp
     src/ur/messages.cpp
-    src/tcp_socket.cpp)
+    src/ur/robot_mode.cpp
+    src/ur/rt_state.cpp
+    src/ur/server.cpp
+    src/ur/stream.cpp)
 
 add_executable(ur_driver ${${PROJECT_NAME}_SOURCES} src/ros_main.cpp)
 add_dependencies(ur_driver ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
@@ -96,7 +97,7 @@ target_link_libraries(ur_driver
  )
 
 
-install(DIRECTORY launch config
+install(DIRECTORY config launch
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
 install(TARGETS ur_driver ur_hardware_interface
@@ -112,9 +113,9 @@ install(DIRECTORY include/${PROJECT_NAME}/
 
 if (CATKIN_ENABLE_TESTING)
   set(${PROJECT_NAME}_TEST_SOURCES
-    tests/ur/rt_state.cpp
     tests/ur/master_board.cpp
-    tests/ur/robot_mode.cpp)
+    tests/ur/robot_mode.cpp
+    tests/ur/rt_state.cpp)
 
   catkin_add_gtest(ur_modern_driver_test ${${PROJECT_NAME}_SOURCES} ${${PROJECT_NAME}_TEST_SOURCES} tests/main.cpp)
   target_link_libraries(ur_modern_driver_test ur_hardware_interface ${catkin_LIBRARIES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,8 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(ur_modern_driver)
 
-
 add_definitions( -DROS_BUILD )
 
-
-## Find catkin macros and libraries
-## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
-## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS
   hardware_interface
   controller_manager
@@ -23,104 +18,24 @@ find_package(catkin REQUIRED COMPONENTS
   tf
 )
 
-## System dependencies are found with CMake's conventions
-# find_package(Boost REQUIRED COMPONENTS system)
 
-
-## Uncomment this if the package has a setup.py. This macro ensures
-## modules and global scripts declared therein get installed
-## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
-# catkin_python_setup()
-
-################################################
-## Declare ROS messages, services and actions ##
-################################################
-
-## To declare and build messages, services or actions from within this
-## package, follow these steps:
-## * Let MSG_DEP_SET be the set of packages whose message types you use in
-##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
-## * In the file package.xml:
-##   * add a build_depend tag for "message_generation"
-##   * add a build_depend and a run_depend tag for each package in MSG_DEP_SET
-##   * If MSG_DEP_SET isn't empty the following dependency has been pulled in
-##     but can be declared for certainty nonetheless:
-##     * add a run_depend tag for "message_runtime"
-## * In this file (CMakeLists.txt):
-##   * add "message_generation" and every package in MSG_DEP_SET to
-##     find_package(catkin REQUIRED COMPONENTS ...)
-##   * add "message_runtime" and every package in MSG_DEP_SET to
-##     catkin_package(CATKIN_DEPENDS ...)
-##   * uncomment the add_*_files sections below as needed
-##     and list every .msg/.srv/.action file to be processed
-##   * uncomment the generate_messages entry below
-##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
-
-## Generate messages in the 'msg' folder
-# add_message_files(
-#   FILES
-#   Message1.msg
-#   Message2.msg
-# )
-
-## Generate services in the 'srv' folder
-# add_service_files(
-#   FILES
-#   Service1.srv
-#   Service2.srv
-# )
-
-## Generate actions in the 'action' folder
-# add_action_files(
-#   FILES
-#   Action1.action
-#   Action2.action
-# )
-
-## Generate added messages and services with any dependencies listed here
-# generate_messages(
-#   DEPENDENCIES
-#   control_msgs#   geometry_msgs#   sensor_msgs#   trajectory_msgs#   ur_msgs
-# )
-
-################################################
-## Declare ROS dynamic reconfigure parameters ##
-################################################
-
-## To declare and build dynamic reconfigure parameters within this
-## package, follow these steps:
-## * In the file package.xml:
-##   * add a build_depend and a run_depend tag for "dynamic_reconfigure"
-## * In this file (CMakeLists.txt):
-##   * add "dynamic_reconfigure" to
-##     find_package(catkin REQUIRED COMPONENTS ...)
-##   * uncomment the "generate_dynamic_reconfigure_options" section below
-##     and list every .cfg file to be processed
-
-## Generate dynamic reconfigure parameters in the 'cfg' folder
-# generate_dynamic_reconfigure_options(
-#   cfg/DynReconf1.cfg
-#   cfg/DynReconf2.cfg
-# )
-
-###################################
-## catkin specific configuration ##
-###################################
-## The catkin_package macro generates cmake config files for your package
-## Declare things to be passed to dependent projects
-## INCLUDE_DIRS: uncomment this if you package contains header files
-## LIBRARIES: libraries you create in this project that dependent projects also need
-## CATKIN_DEPENDS: catkin_packages dependent projects also need
-## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
-  INCLUDE_DIRS include
-  LIBRARIES ur_hardware_interface
-  CATKIN_DEPENDS hardware_interface controller_manager actionlib control_msgs geometry_msgs roscpp sensor_msgs trajectory_msgs ur_msgs
+  INCLUDE_DIRS
+    include
+  LIBRARIES
+    ur_hardware_interface
+  CATKIN_DEPENDS
+    hardware_interface
+    controller_manager
+    actionlib
+    control_msgs
+    geometry_msgs
+    roscpp
+    sensor_msgs
+    trajectory_msgs
+    ur_msgs
 )
 
-###########
-## Build ##
-###########
 
 # check c++11 / c++0x
 include(CheckCXXCompilerFlag)
@@ -143,29 +58,18 @@ if("${controller_manager_msgs_VERSION}" VERSION_LESS "0.10.0")
     add_definitions(-DUR_ROS_CONTROL_INTERFACE_OLD_ROS_CONTROL)
 endif()
 
-## Specify additional locations of header files
-## Your package locations should be listed before other locations
-# include_directories(include)
-include_directories(include
+include_directories(
+  include
   ${catkin_INCLUDE_DIRS}
 )
-
-## Declare a C++ library
 
 # Hardware Interface
 add_library(ur_hardware_interface
   src/ros/hardware_interface.cpp
   src/ros/controller.cpp)
-target_link_libraries(ur_hardware_interface
-  ${catkin_LIBRARIES}
-)
+target_link_libraries(ur_hardware_interface ${catkin_LIBRARIES})
 
-## Add cmake target dependencies of the library
-## as an example, code may need to be generated before libraries
-## either from message generation or dynamic reconfigure
-# add_dependencies(ur_modern_driver ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
-## Declare a C++ executable
 set(${PROJECT_NAME}_SOURCES
     src/ros/action_server.cpp
     src/ros/mb_publisher.cpp
@@ -184,54 +88,33 @@ set(${PROJECT_NAME}_SOURCES
     src/tcp_socket.cpp)
 
 add_executable(ur_driver ${${PROJECT_NAME}_SOURCES} src/ros_main.cpp)
-
-## Add cmake target dependencies of the executable
-## same as for the library above
 add_dependencies(ur_driver ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-
-## Specify libraries to link a library or executable target against
 target_link_libraries(ur_driver
   ur_hardware_interface
   ${catkin_LIBRARIES}
  )
 
-#############
-## Install ##
-#############
 
-install(DIRECTORY launch/ DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch)
-install(DIRECTORY config/ DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/config)
+install(DIRECTORY launch config
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
-## Mark executables and/or libraries for installation
 install(TARGETS ur_driver ur_hardware_interface
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
-## Mark cpp header files for installation
 install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
   FILES_MATCHING PATTERN "*.h"
 )
 
-## Mark other files for installation (e.g. launch and bag files, etc.)
-# install(FILES
-#   # myfile1
-#   # myfile2
-#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-# )
 
-#############
-## Testing ##
-#############
-
-
-set(${PROJECT_NAME}_TEST_SOURCES
+if (CATKIN_ENABLE_TESTING)
+  set(${PROJECT_NAME}_TEST_SOURCES
     tests/ur/rt_state.cpp
     tests/ur/master_board.cpp
     tests/ur/robot_mode.cpp)
 
-if (CATKIN_ENABLE_TESTING)
   catkin_add_gtest(ur_modern_driver_test ${${PROJECT_NAME}_SOURCES} ${${PROJECT_NAME}_TEST_SOURCES} tests/main.cpp)
   target_link_libraries(ur_modern_driver_test ur_hardware_interface ${catkin_LIBRARIES})
 endif()

--- a/package.xml
+++ b/package.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<package>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="2">
   <name>ur_modern_driver</name>
   <version>0.1.0</version>
   <description>The new driver for Universal Robots UR3, UR5 and UR10 robots with CB2 and CB3 controllers.</description>
@@ -14,36 +15,24 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>hardware_interface</build_depend>
-  <build_depend>controller_manager</build_depend>
-  <build_depend>actionlib</build_depend>
-  <build_depend>control_msgs</build_depend>
-  <build_depend>geometry_msgs</build_depend>
-  <build_depend>industrial_msgs</build_depend>
-  <build_depend>roscpp</build_depend>
-  <build_depend>sensor_msgs</build_depend>
-  <build_depend>trajectory_msgs</build_depend>
-  <build_depend>ur_msgs</build_depend>
-  <build_depend>tf</build_depend>
-  <build_depend>std_srvs</build_depend>
+  <depend>hardware_interface</depend>
+  <depend>controller_manager</depend>
+  <depend>actionlib</depend>
+  <depend>control_msgs</depend>
+  <depend>geometry_msgs</depend>
+  <depend>industrial_msgs</depend>
+  <depend>roscpp</depend>
+  <depend>sensor_msgs</depend>
+  <depend>trajectory_msgs</depend>
+  <depend>ur_msgs</depend>
+  <depend>tf</depend>
+  <depend>std_srvs</depend>
 
-  <run_depend>hardware_interface</run_depend>
-  <run_depend>controller_manager</run_depend>
-  <run_depend>force_torque_sensor_controller</run_depend>
-  <run_depend>joint_state_controller</run_depend>
-  <run_depend>joint_trajectory_controller</run_depend>
-  <run_depend>actionlib</run_depend>
-  <run_depend>control_msgs</run_depend>
-  <run_depend>geometry_msgs</run_depend>
-  <run_depend>industrial_msgs</run_depend>
-  <run_depend>roscpp</run_depend>
-  <run_depend>sensor_msgs</run_depend>
-  <run_depend>trajectory_msgs</run_depend>
-  <run_depend>ur_msgs</run_depend>
-  <run_depend>ur_description</run_depend>
-  <run_depend>tf</run_depend>
-  <run_depend>std_srvs</run_depend>
-  <run_depend>robot_state_publisher</run_depend>
+  <exec_depend>force_torque_sensor_controller</exec_depend>
+  <exec_depend>joint_state_controller</exec_depend>
+  <exec_depend>joint_trajectory_controller</exec_depend>
+  <exec_depend>ur_description</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
 
   <test_depend>rosunit</test_depend>
 </package>

--- a/package.xml
+++ b/package.xml
@@ -6,7 +6,7 @@
   <author>Thomas Timm Andersen</author>
   <author>Simon Rasmussen</author>
   <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
-  <license>Beerware</license>
+  <license>Apache 2.0</license>
 
   <url type="website">http://wiki.ros.org/ur_modern_driver</url>
   <url type="bugtracker">https://github.com/ros-industrial/ur_modern_driver/issues</url>

--- a/package.xml
+++ b/package.xml
@@ -7,6 +7,7 @@
   <author>Thomas Timm Andersen</author>
   <author>Simon Rasmussen</author>
   <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
+  <maintainer email="nhg@ipa.fhg.de">Nadia Hammoudeh Garcia</maintainer>
   <license>Apache 2.0</license>
 
   <url type="website">http://wiki.ros.org/ur_modern_driver</url>

--- a/package.xml
+++ b/package.xml
@@ -1,45 +1,19 @@
 <?xml version="1.0"?>
 <package>
   <name>ur_modern_driver</name>
-  <version>0.0.1</version>
-  <description>The new driver for the UR3/UR5/UR10 robot arms from universal robots</description>
-
-  <!-- One maintainer tag required, multiple allowed, one person per tag -->
-  <!-- Example:  -->
-  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
-  <maintainer email="thomas.timm.dk@gmail.com">Thomas Timm Andersen</maintainer>
-
-
-  <!-- One license tag required, multiple allowed, one license per tag -->
-  <!-- Commonly used license strings: -->
-  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
+  <version>0.1.0</version>
+  <description>The new driver for Universal Robots UR3, UR5 and UR10 robots with CB2 and CB3 controllers.</description>
+  <author>Thomas Timm Andersen</author>
+  <author>Simon Rasmussen</author>
+  <maintainer email="g.a.vanderhoorn@tudelft.nl">G.A. vd. Hoorn (TU Delft Robotics Institute)</maintainer>
   <license>Beerware</license>
 
-
-  <!-- Url tags are optional, but mutiple are allowed, one per tag -->
-  <!-- Optional attribute type can be: website, bugtracker, or repository -->
-  <!-- Example: -->
   <url type="website">http://wiki.ros.org/ur_modern_driver</url>
+  <url type="bugtracker">https://github.com/ros-industrial/ur_modern_driver/issues</url>
+  <url type="repository">https://github.com/ros-industrial/ur_modern_driver</url>
 
-
-  <!-- Author tags are optional, mutiple are allowed, one per tag -->
-  <!-- Authors do not have to be maintianers, but could be -->
-  <!-- Example: -->
-  <author email="thomas.timm.dk@gmail.com">Thomas Timm Andersen</author>
-
-
-  <!-- The *_depend tags are used to specify dependencies -->
-  <!-- Dependencies can be catkin packages or system dependencies -->
-  <!-- Examples: -->
-  <!-- Use build_depend for packages you need at compile time: -->
-  <!--   <build_depend>message_generation</build_depend> -->
-  <!-- Use buildtool_depend for build tool packages: -->
-  <!--   <buildtool_depend>catkin</buildtool_depend> -->
-  <!-- Use run_depend for packages you need at runtime: -->
-  <!--   <run_depend>message_runtime</run_depend> -->
-  <!-- Use test_depend for packages you need only for testing: -->
-  <!--   <test_depend>gtest</test_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
+
   <build_depend>hardware_interface</build_depend>
   <build_depend>controller_manager</build_depend>
   <build_depend>actionlib</build_depend>
@@ -52,6 +26,7 @@
   <build_depend>ur_msgs</build_depend>
   <build_depend>tf</build_depend>
   <build_depend>std_srvs</build_depend>
+
   <run_depend>hardware_interface</run_depend>
   <run_depend>controller_manager</run_depend>
   <run_depend>force_torque_sensor_controller</run_depend>
@@ -71,10 +46,4 @@
   <run_depend>robot_state_publisher</run_depend>
 
   <test_depend>rosunit</test_depend>
-
-  <!-- The export tag contains other, unspecified, tags -->
-  <export>
-    <!-- Other tools can request additional information be placed here -->
-
-  </export>
 </package>


### PR DESCRIPTION
Summary:

 - updated maintainers and authors section
 - removed all boilerplate comments
 - made `catkin_lint` happier (sorting lists, adding missing dependency declarations, etc)
 - upgraded manifest to format 2
