### PR TITLE
Resolve premature controller initialization

### DIFF
--- a/include/ur_modern_driver/pipeline.h
+++ b/include/ur_modern_driver/pipeline.h
@@ -159,10 +159,11 @@ private:
     unique_ptr<T> product;
     while (running_)
     {
-      // 16000us timeout was chosen because we should
-      // roughly recieve messages at 125hz which is every
-      // 8ms so double it for some error margin
-      if (!queue_.wait_dequeue_timed(product, std::chrono::milliseconds(16)))
+      // timeout was chosen because we should receive messages
+      // at roughly 125hz (every 8ms) and have to update
+      // the controllers (i.e. the consumer) with *at least* 125Hz
+      // So we update the consumer more frequently via onTimeout
+      if (!queue_.wait_dequeue_timed(product, std::chrono::milliseconds(8)))
       {
         consumer_.onTimeout();
         continue;

--- a/include/ur_modern_driver/pipeline.h
+++ b/include/ur_modern_driver/pipeline.h
@@ -159,11 +159,10 @@ private:
     unique_ptr<T> product;
     while (running_)
     {
-      // timeout was chosen because we should receive messages
-      // at roughly 125hz (every 8ms) and have to update
-      // the controllers (i.e. the consumer) with *at least* 125Hz
-      // So we update the consumer more frequently via onTimeout
-      if (!queue_.wait_dequeue_timed(product, std::chrono::milliseconds(8)))
+      // 16000us timeout was chosen because we should
+      // roughly recieve messages at 125hz which is every
+      // 8ms so double it for some error margin
+      if (!queue_.wait_dequeue_timed(product, std::chrono::milliseconds(16)))
       {
         consumer_.onTimeout();
         continue;

--- a/include/ur_modern_driver/ros/controller.h
+++ b/include/ur_modern_driver/ros/controller.h
@@ -19,6 +19,7 @@ private:
   ros::NodeHandle nh_;
   ros::Time lastUpdate_;
   controller_manager::ControllerManager controller_;
+  bool state_initialized_;
 
   // state interfaces
   JointInterface joint_interface_;

--- a/include/ur_modern_driver/ros/controller.h
+++ b/include/ur_modern_driver/ros/controller.h
@@ -19,7 +19,7 @@ private:
   ros::NodeHandle nh_;
   ros::Time lastUpdate_;
   controller_manager::ControllerManager controller_;
-  bool state_initialized_;
+  bool robot_state_received_;
 
   // state interfaces
   JointInterface joint_interface_;

--- a/include/ur_modern_driver/ros/controller.h
+++ b/include/ur_modern_driver/ros/controller.h
@@ -85,5 +85,7 @@ public:
     return update();
   }
 
+  virtual void onTimeout();
+
   virtual void onRobotStateChange(RobotState state);
 };

--- a/include/ur_modern_driver/ros/controller.h
+++ b/include/ur_modern_driver/ros/controller.h
@@ -85,7 +85,5 @@ public:
     return update();
   }
 
-  virtual void onTimeout();
-
   virtual void onRobotStateChange(RobotState state);
 };

--- a/src/ros/controller.cpp
+++ b/src/ros/controller.cpp
@@ -109,11 +109,6 @@ bool ROSController::update()
   return write();
 }
 
-void ROSController::onTimeout()
-{
-  update();
-}
-
 void ROSController::onRobotStateChange(RobotState state)
 {
   bool next = (state == RobotState::Running);

--- a/src/ros/controller.cpp
+++ b/src/ros/controller.cpp
@@ -109,6 +109,11 @@ bool ROSController::update()
   return write();
 }
 
+void ROSController::onTimeout()
+{
+  update();
+}
+
 void ROSController::onRobotStateChange(RobotState state)
 {
   bool next = (state == RobotState::Running);

--- a/src/ros/controller.cpp
+++ b/src/ros/controller.cpp
@@ -80,9 +80,9 @@ void ROSController::reset()
 
 void ROSController::read(RTShared& packet)
 {
-  state_initialized_ = true;
   joint_interface_.update(packet);
   wrench_interface_.update(packet);
+  state_initialized_ = true;
 }
 
 bool ROSController::update()

--- a/src/ros/controller.cpp
+++ b/src/ros/controller.cpp
@@ -3,6 +3,7 @@
 ROSController::ROSController(URCommander& commander, TrajectoryFollower& follower,
                              std::vector<std::string>& joint_names, double max_vel_change, std::string tcp_link)
   : controller_(this, nh_)
+  , state_initialized_(false)
   , joint_interface_(joint_names)
   , wrench_interface_(tcp_link)
   , position_interface_(follower, joint_interface_, joint_names)
@@ -79,6 +80,7 @@ void ROSController::reset()
 
 void ROSController::read(RTShared& packet)
 {
+  state_initialized_ = true;
   joint_interface_.update(packet);
   wrench_interface_.update(packet);
 }
@@ -111,7 +113,8 @@ bool ROSController::update()
 
 void ROSController::onTimeout()
 {
-  update();
+  if (state_initialized_)
+    update();
 }
 
 void ROSController::onRobotStateChange(RobotState state)


### PR DESCRIPTION
In my (admittedly limited) tests this resolves #206.

It partially reverts the changes in zagitta/ur_modern_driver#6, in particular the code that ensures the controllers are updated at a minimum rate of 125Hz.