### PR TITLE
Setting UR3 PID values to avoid oscillations.

### DIFF
--- a/config/ur3_controllers.yaml
+++ b/config/ur3_controllers.yaml
@@ -1,5 +1,3 @@
-# Currently simply a copy of ur5_controllers.yaml
-
 # Settings for ros_control control loop
 hardware_control_loop:
    loop_hz: 125
@@ -77,12 +75,21 @@ vel_based_pos_traj_controller:
    action_monitor_rate: 10
    gains:
       #!!These values have not been optimized!!
-      shoulder_pan_joint: {p: 50.0,  i: 0.0, d: 0.1, i_clamp: 1}
-      shoulder_lift_joint: {p: 50.0,  i: 0.0, d: 0.1, i_clamp: 1}
-      elbow_joint: {p: 50.0,  i: 0.0, d: 0.1, i_clamp: 1}
-      wrist_1_joint: {p: 50.0,  i: 0.0, d: 0.1, i_clamp: 1}
-      wrist_2_joint: {p: 50.0,  i: 0.0, d: 0.1, i_clamp: 1}
-      wrist_3_joint: {p: 50.0,  i: 0.0, d: 0.1, i_clamp: 1}
+      shoulder_pan_joint:  {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
+      shoulder_lift_joint: {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
+      elbow_joint:         {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
+      wrist_1_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
+      wrist_2_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
+      wrist_3_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
+
+   # Use a feedforward term to reduce the size of PID gains
+   velocity_ff:
+    shoulder_pan_joint: 1.0
+    shoulder_lift_joint: 1.0
+    elbow_joint: 1.0
+    wrist_1_joint: 1.0
+    wrist_2_joint: 1.0
+    wrist_3_joint: 1.0
 
    # state_publish_rate:  50 # Defaults to 50
    # action_monitor_rate: 20 # Defaults to 20


### PR DESCRIPTION
With the previous ros_control PID values, I was seeing dangerous oscillations. So I decreased Kp until oscillations were no longer observed.  [video of previous oscillations](https://drive.google.com/open?id=1H97_EFh-2xF-uiryyOl_Tz2FMlLV_nMH) -- [video of testing](https://drive.google.com/file/d/1-TDyDzqb_8oaDNL4mG1ihsJy9wVIVAsu/view?usp=sharing)

The second commit implements a feedforward term. After implementing this, the gains could be decreased even more.

