### PR TITLE
kinetic-devel: select CMake build type if not configured.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,11 @@ project(ur_modern_driver)
 
 add_definitions( -DROS_BUILD )
 
+if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
+  message("${PROJECT_NAME}: You did not request a specific build type: selecting 'RelWithDebInfo'.")
+  set(CMAKE_BUILD_TYPE RelWithDebInfo)
+endif()
+
 find_package(catkin REQUIRED
   COMPONENTS
     actionlib


### PR DESCRIPTION
As per subject.

See the commit comment for rationale.

Summary: CPU usage for an unoptimised build is quite a bit higher than for an optimised one.

If user has not explicitly set a build type, select `RelWithDebInfo`, which is equivalent to `Release` with debug symbols enabled.
