### PR TITLE
Rename hold_trajectory_duration to stop_trajectory_duration

### DIFF
--- a/config/ur10_controllers.yaml
+++ b/config/ur10_controllers.yaml
@@ -48,7 +48,7 @@ pos_based_pos_traj_controller:
 
    # state_publish_rate:  50 # Defaults to 50
    # action_monitor_rate: 20 # Defaults to 20
-   #hold_trajectory_duration: 0 # Defaults to 0.5
+   #stop_trajectory_duration: 0 # Defaults to 0.0
 
 # Joint Trajectory Controller -------------------------------
 # For detailed explanations of parameter see http://wiki.ros.org/joint_trajectory_controller
@@ -93,7 +93,7 @@ vel_based_pos_traj_controller:
 
    # state_publish_rate:  50 # Defaults to 50
    # action_monitor_rate: 20 # Defaults to 20
-   #hold_trajectory_duration: 0 # Defaults to 0.5
+   #stop_trajectory_duration: 0 # Defaults to 0.0
 
 # Pass an array of joint velocities directly to the joints
 joint_group_vel_controller:

--- a/config/ur3_controllers.yaml
+++ b/config/ur3_controllers.yaml
@@ -48,7 +48,7 @@ pos_based_pos_traj_controller:
 
    # state_publish_rate:  50 # Defaults to 50
    # action_monitor_rate: 20 # Defaults to 20
-   #hold_trajectory_duration: 0 # Defaults to 0.5
+   #stop_trajectory_duration: 0 # Defaults to 0.0
 
 # Joint Trajectory Controller - velocity based -------------------------------
 # For detailed explanations of parameter see http://wiki.ros.org/joint_trajectory_controller
@@ -93,7 +93,7 @@ vel_based_pos_traj_controller:
 
    # state_publish_rate:  50 # Defaults to 50
    # action_monitor_rate: 20 # Defaults to 20
-   #hold_trajectory_duration: 0 # Defaults to 0.5
+   #stop_trajectory_duration: 0 # Defaults to 0.0
 
 # Pass an array of joint velocities directly to the joints
 joint_group_vel_controller:

--- a/config/ur5_controllers.yaml
+++ b/config/ur5_controllers.yaml
@@ -48,7 +48,7 @@ pos_based_pos_traj_controller:
 
    # state_publish_rate:  50 # Defaults to 50
    # action_monitor_rate: 20 # Defaults to 20
-   #hold_trajectory_duration: 0 # Defaults to 0.5
+   #stop_trajectory_duration: 0 # Defaults to 0.0
    
 # Joint Trajectory Controller - velocity based -------------------------------
 # For detailed explanations of parameter see http://wiki.ros.org/joint_trajectory_controller
@@ -84,7 +84,7 @@ vel_based_pos_traj_controller:
 
    # state_publish_rate:  50 # Defaults to 50
    # action_monitor_rate: 20 # Defaults to 20
-   #hold_trajectory_duration: 0 # Defaults to 0.5
+   #stop_trajectory_duration: 0 # Defaults to 0.0
 
 # Pass an array of joint velocities directly to the joints
 joint_group_vel_controller:


### PR DESCRIPTION
Related to the issue: https://github.com/ros-industrial/ur_modern_driver/issues/240

the parameter was renamed for the ros_controllers 0.6.0 version https://github.com/ros-controls/ros_controllers/blob/eb094a7f3c01f3ab03b87027c42a75611c602110/joint_trajectory_controller/CHANGELOG.rst#060-2014-02-05 

For melodic the `hold_trajectory_duration` is not supported