### PR TITLE
Publish native tool position/velocity when ros_control is enabled

### DIFF
--- a/src/ros/rt_publisher.cpp
+++ b/src/ros/rt_publisher.cpp
@@ -94,11 +94,10 @@ bool RTPublisher::publish(RTShared& packet)
   bool res = true;
   if (!temp_only_)
   {
-    res = publishJoints(packet, time) && publishWrench(packet, time) && publishTool(packet, time) &&
-          publishTransform(packet, time);
+    res = publishJoints(packet, time) && publishWrench(packet, time);
   }
 
-  return res && publishTemperature(packet, time);
+  return res && publishTool(packet, time) && publishTransform(packet, time) && publishTemperature(packet, time);
 }
 
 bool RTPublisher::consume(RTState_V1_6__7& state)


### PR DESCRIPTION
Before the refactor, the driver used to publish the "native" information about the tool's position and velocity [even when ros_control was enabled](https://github.com/ros-industrial/ur_modern_driver/blob/9397f47ac158fe5976719f33101334371bc15d44/src/ur_ros_wrapper.cpp#L610-L646).

This PR restores that behavior for the refactored version in `kinetic-devel`.