### PR TITLE
Revert "Add arguments to ros_control launchfiles to select loaded controllers."

### DIFF
--- a/launch/ur10_ros_control.launch
+++ b/launch/ur10_ros_control.launch
@@ -10,12 +10,10 @@
   <arg name="limited" default="false"/>
   <arg name="min_payload"  default="0.0"/>
   <arg name="max_payload"  default="3.0"/>
-  <arg name="prefix" default="" />
+  <arg name="prefix" default="" />  
   <arg name="max_velocity" default="10.0"/> <!-- [rad/s] -->
   <arg name="base_frame" default="$(arg prefix)base" />
   <arg name="tool_frame" default="$(arg prefix)tool0_controller" />
-  <arg name="controllers" default="joint_state_controller force_torque_sensor_controller vel_based_pos_traj_controller"/>
-  <arg name="stopped_controllers" default="pos_based_pos_traj_controller"/>
   <!-- robot model -->
   <include file="$(find ur_description)/launch/ur10_upload.launch">
     <arg name="limited" value="$(arg limited)"/>
@@ -40,11 +38,11 @@
 
   <!-- spawn controller manager -->
   <node name="ros_control_controller_spawner" pkg="controller_manager" type="spawner" respawn="false"
-    output="screen" args="$(arg controllers)" />
+    output="screen" args="joint_state_controller force_torque_sensor_controller vel_based_pos_traj_controller" />
 
-  <!-- load other controller -->
+  <!-- load other controller --> 
   <node name="ros_control_controller_manager" pkg="controller_manager" type="controller_manager" respawn="false"
-    output="screen" args="load $(arg stopped_controllers)" />
+    output="screen" args="load pos_based_pos_traj_controller" /> 
 
   <!-- Convert joint states to /tf tranforms -->
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>

--- a/launch/ur3_ros_control.launch
+++ b/launch/ur3_ros_control.launch
@@ -14,8 +14,6 @@
   <arg name="max_velocity" default="10.0"/> <!-- [rad/s] -->
   <arg name="base_frame" default="$(arg prefix)base" />
   <arg name="tool_frame" default="$(arg prefix)tool0_controller" />
-  <arg name="controllers" default="joint_state_controller force_torque_sensor_controller pos_based_pos_traj_controller"/>
-  <arg name="stopped_controllers" default="vel_based_pos_traj_controller"/>
   <!-- robot model -->
   <include file="$(find ur_description)/launch/ur3_upload.launch">
     <arg name="limited" value="$(arg limited)"/>
@@ -40,11 +38,11 @@
 
   <!-- spawn controller manager -->
   <node name="ros_control_controller_spawner" pkg="controller_manager" type="spawner" respawn="false"
-    output="screen" args="$(arg controllers)" />
+    output="screen" args="joint_state_controller force_torque_sensor_controller pos_based_pos_traj_controller" />
 
   <!-- load other controller -->
   <node name="ros_control_controller_manager" pkg="controller_manager" type="controller_manager" respawn="false"
-    output="screen" args="load $(arg stopped_controllers)" />
+    output="screen" args="load vel_based_pos_traj_controller" />
 
   <!-- Convert joint states to /tf tranforms -->
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>

--- a/launch/ur5_ros_control.launch
+++ b/launch/ur5_ros_control.launch
@@ -10,12 +10,10 @@
   <arg name="limited" default="false"/>
   <arg name="min_payload"  default="0.0"/>
   <arg name="max_payload"  default="3.0"/>
-  <arg name="prefix" default="" />
+  <arg name="prefix" default="" />  
   <arg name="max_velocity" default="10.0"/> <!-- [rad/s] -->
   <arg name="base_frame" default="$(arg prefix)base" />
   <arg name="tool_frame" default="$(arg prefix)tool0_controller" />
-  <arg name="controllers" default="joint_state_controller force_torque_sensor_controller vel_based_pos_traj_controller"/>
-  <arg name="stopped_controllers" default="pos_based_pos_traj_controller"/>
   <!-- robot model -->
   <include file="$(find ur_description)/launch/ur5_upload.launch">
     <arg name="limited" value="$(arg limited)"/>
@@ -40,11 +38,11 @@
 
   <!-- spawn controller manager -->
   <node name="ros_control_controller_spawner" pkg="controller_manager" type="spawner" respawn="false"
-    output="screen" args="$(arg controllers)" />
+    output="screen" args="joint_state_controller force_torque_sensor_controller vel_based_pos_traj_controller" />
 
-  <!-- load other controller -->
+  <!-- load other controller --> 
   <node name="ros_control_controller_manager" pkg="controller_manager" type="controller_manager" respawn="false"
-    output="screen" args="load $(arg stopped_controllers)" />
+    output="screen" args="load pos_based_pos_traj_controller" /> 
 
   <!-- Convert joint states to /tf tranforms -->
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>


### PR DESCRIPTION
Reverts ros-industrial/ur_modern_driver#149.

Should have been targeted at `kinetic-devel`.
