### PR TITLE
Upstream source tests

### DIFF
--- a/.travis.rosinstall.kinetic
+++ b/.travis.rosinstall.kinetic
@@ -1,0 +1,4 @@
+- git:
+    local-name: universal_robot
+    uri: 'https://github.com/ros-industrial/universal_robot.git'
+    version: kinetic-devel

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,11 @@ env:
     - ROS_DISTRO="indigo"  ROS_REPO=ros-shadow-fixed NOT_TEST_INSTALL=true
     - ROS_DISTRO="kinetic" ROS_REPO=ros              NOT_TEST_INSTALL=true
     - ROS_DISTRO="kinetic" ROS_REPO=ros-shadow-fixed NOT_TEST_INSTALL=true
+    - ROS_DISTRO="kinetic" ROS_REPO=ros              NOT_TEST_INSTALL=true UPSTREAM_WORKSPACE=file
+    - ROS_DISTRO="kinetic" ROS_REPO=ros-shadow-fixed NOT_TEST_INSTALL=true UPSTREAM_WORKSPACE=file
     - ROS_DISTRO="kinetic" CLANG_FORMAT_CHECK=file
 
 install:
   - git clone --depth=1 https://github.com/ros-industrial/industrial_ci.git .ci_config
-script: 
+script:
   - .ci_config/travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,12 @@ env:
     - ROS_DISTRO="kinetic" ROS_REPO=ros              NOT_TEST_INSTALL=true UPSTREAM_WORKSPACE=file
     - ROS_DISTRO="kinetic" ROS_REPO=ros-shadow-fixed NOT_TEST_INSTALL=true UPSTREAM_WORKSPACE=file
     - ROS_DISTRO="kinetic" CLANG_FORMAT_CHECK=file
+matrix:
+  allow_failures:
+    - env: ROS_DISTRO="indigo"  ROS_REPO=ros              NOT_TEST_INSTALL=true
+    - env: ROS_DISTRO="indigo"  ROS_REPO=ros-shadow-fixed NOT_TEST_INSTALL=true
+    - env: ROS_DISTRO="kinetic" ROS_REPO=ros              NOT_TEST_INSTALL=true
+    - env: ROS_DISTRO="kinetic" ROS_REPO=ros-shadow-fixed NOT_TEST_INSTALL=true
 
 install:
   - git clone --depth=1 https://github.com/ros-industrial/industrial_ci.git .ci_config


### PR DESCRIPTION
Add a set of checks against a source checkout of `universal_robot` repo in `kinetic`.

See #266.