### PR TITLE
Drop Indigo support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ env:
   global:
     - CCACHE_DIR=$HOME/.ccache
   matrix:
-    - ROS_DISTRO="indigo"  ROS_REPO=ros              NOT_TEST_INSTALL=true
-    - ROS_DISTRO="indigo"  ROS_REPO=ros-shadow-fixed NOT_TEST_INSTALL=true
     - ROS_DISTRO="kinetic" ROS_REPO=ros              NOT_TEST_INSTALL=true
     - ROS_DISTRO="kinetic" ROS_REPO=ros-shadow-fixed NOT_TEST_INSTALL=true
     - ROS_DISTRO="kinetic" ROS_REPO=ros              NOT_TEST_INSTALL=true UPSTREAM_WORKSPACE=file
@@ -19,8 +17,6 @@ env:
     - ROS_DISTRO="kinetic" CLANG_FORMAT_CHECK=file
 matrix:
   allow_failures:
-    - env: ROS_DISTRO="indigo"  ROS_REPO=ros              NOT_TEST_INSTALL=true
-    - env: ROS_DISTRO="indigo"  ROS_REPO=ros-shadow-fixed NOT_TEST_INSTALL=true
     - env: ROS_DISTRO="kinetic" ROS_REPO=ros              NOT_TEST_INSTALL=true
     - env: ROS_DISTRO="kinetic" ROS_REPO=ros-shadow-fixed NOT_TEST_INSTALL=true
 


### PR DESCRIPTION
#247 effectively made this driver not support Indigo. Unless we decide to backport ros-industrial/universal_robot#395 (and possibly ros-industrial/universal_robot#416, and maybe others) to Indigo and trigger another release, that will continue to be the case.

I, therefore, think we should drop the Indigo tests in this repo.