### PR TITLE
Updated for SW>=3.5 and E-series

### DIFF
--- a/config/ur10e_controllers.yaml
+++ b/config/ur10e_controllers.yaml
@@ -1,0 +1,107 @@
+# Settings for ros_control control loop
+hardware_control_loop:
+   loop_hz: 125
+
+# Settings for ros_control hardware interface
+hardware_interface:
+   joints:
+     - shoulder_pan_joint
+     - shoulder_lift_joint
+     - elbow_joint
+     - wrist_1_joint
+     - wrist_2_joint
+     - wrist_3_joint
+
+# Publish all joint states ----------------------------------
+joint_state_controller:
+   type:         joint_state_controller/JointStateController
+   publish_rate: 125
+
+# Publish wrench ----------------------------------
+force_torque_sensor_controller:
+   type:         force_torque_sensor_controller/ForceTorqueSensorController
+   publish_rate: 125
+
+# Joint Trajectory Controller - position based -------------------------------
+# For detailed explanations of parameter see http://wiki.ros.org/joint_trajectory_controller
+pos_based_pos_traj_controller:
+   type: position_controllers/JointTrajectoryController
+   joints:
+     - shoulder_pan_joint
+     - shoulder_lift_joint
+     - elbow_joint
+     - wrist_1_joint
+     - wrist_2_joint
+     - wrist_3_joint
+   constraints:
+      goal_time: 0.6
+      stopped_velocity_tolerance: 0.05
+      shoulder_pan_joint: {trajectory: 0.1, goal: 0.1}
+      shoulder_lift_joint: {trajectory: 0.1, goal: 0.1}
+      elbow_joint: {trajectory: 0.1, goal: 0.1}
+      wrist_1_joint: {trajectory: 0.1, goal: 0.1}
+      wrist_2_joint: {trajectory: 0.1, goal: 0.1}
+      wrist_3_joint: {trajectory: 0.1, goal: 0.1}
+   stop_trajectory_duration: 0.5
+   state_publish_rate:  125
+   action_monitor_rate: 10
+
+   # state_publish_rate:  50 # Defaults to 50
+   # action_monitor_rate: 20 # Defaults to 20
+   #stop_trajectory_duration: 0 # Defaults to 0.0
+
+# Joint Trajectory Controller -------------------------------
+# For detailed explanations of parameter see http://wiki.ros.org/joint_trajectory_controller
+vel_based_pos_traj_controller:
+   type: velocity_controllers/JointTrajectoryController
+   joints:
+     - shoulder_pan_joint
+     - shoulder_lift_joint
+     - elbow_joint
+     - wrist_1_joint
+     - wrist_2_joint
+     - wrist_3_joint
+   constraints:
+      goal_time: 0.6
+      stopped_velocity_tolerance: 0.05
+      shoulder_pan_joint: {trajectory: 0.1, goal: 0.1}
+      shoulder_lift_joint: {trajectory: 0.1, goal: 0.1}
+      elbow_joint: {trajectory: 0.1, goal: 0.1}
+      wrist_1_joint: {trajectory: 0.1, goal: 0.1}
+      wrist_2_joint: {trajectory: 0.1, goal: 0.1}
+      wrist_3_joint: {trajectory: 0.1, goal: 0.1}
+   stop_trajectory_duration: 0.5
+   state_publish_rate:  125
+   action_monitor_rate: 10
+   gains:
+      #!!These values have not been optimized!!
+      shoulder_pan_joint:  {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
+      shoulder_lift_joint: {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
+      elbow_joint:         {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
+      wrist_1_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
+      wrist_2_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
+      wrist_3_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
+
+   # Use a feedforward term to reduce the size of PID gains
+   velocity_ff:
+      shoulder_pan_joint: 1.0
+      shoulder_lift_joint: 1.0
+      elbow_joint: 1.0
+      wrist_1_joint: 1.0
+      wrist_2_joint: 1.0
+      wrist_3_joint: 1.0
+
+   # state_publish_rate:  50 # Defaults to 50
+   # action_monitor_rate: 20 # Defaults to 20
+   #stop_trajectory_duration: 0 # Defaults to 0.0
+
+# Pass an array of joint velocities directly to the joints
+joint_group_vel_controller:
+   type: velocity_controllers/JointGroupVelocityController
+   joints:
+     - shoulder_pan_joint
+     - shoulder_lift_joint
+     - elbow_joint
+     - wrist_1_joint
+     - wrist_2_joint
+     - wrist_3_joint

--- a/config/ur3e_controllers.yaml
+++ b/config/ur3e_controllers.yaml
@@ -1,0 +1,107 @@
+# Settings for ros_control control loop
+hardware_control_loop:
+   loop_hz: 125
+
+# Settings for ros_control hardware interface
+hardware_interface:
+   joints:
+     - shoulder_pan_joint
+     - shoulder_lift_joint
+     - elbow_joint
+     - wrist_1_joint
+     - wrist_2_joint
+     - wrist_3_joint
+
+# Publish all joint states ----------------------------------
+joint_state_controller:
+   type:         joint_state_controller/JointStateController
+   publish_rate: 125
+
+# Publish wrench ----------------------------------
+force_torque_sensor_controller:
+   type:         force_torque_sensor_controller/ForceTorqueSensorController
+   publish_rate: 125
+
+# Joint Trajectory Controller - position based -------------------------------
+# For detailed explanations of parameter see http://wiki.ros.org/joint_trajectory_controller
+pos_based_pos_traj_controller:
+   type: position_controllers/JointTrajectoryController
+   joints:
+     - shoulder_pan_joint
+     - shoulder_lift_joint
+     - elbow_joint
+     - wrist_1_joint
+     - wrist_2_joint
+     - wrist_3_joint
+   constraints:
+      goal_time: 0.6
+      stopped_velocity_tolerance: 0.05
+      shoulder_pan_joint: {trajectory: 0.1, goal: 0.1}
+      shoulder_lift_joint: {trajectory: 0.1, goal: 0.1}
+      elbow_joint: {trajectory: 0.1, goal: 0.1}
+      wrist_1_joint: {trajectory: 0.1, goal: 0.1}
+      wrist_2_joint: {trajectory: 0.1, goal: 0.1}
+      wrist_3_joint: {trajectory: 0.1, goal: 0.1}
+   stop_trajectory_duration: 0.5
+   state_publish_rate:  125
+   action_monitor_rate: 10
+
+   # state_publish_rate:  50 # Defaults to 50
+   # action_monitor_rate: 20 # Defaults to 20
+   #stop_trajectory_duration: 0 # Defaults to 0.0
+
+# Joint Trajectory Controller - velocity based -------------------------------
+# For detailed explanations of parameter see http://wiki.ros.org/joint_trajectory_controller
+vel_based_pos_traj_controller:
+   type: velocity_controllers/JointTrajectoryController
+   joints:
+     - shoulder_pan_joint
+     - shoulder_lift_joint
+     - elbow_joint
+     - wrist_1_joint
+     - wrist_2_joint
+     - wrist_3_joint
+   constraints:
+      goal_time: 0.6
+      stopped_velocity_tolerance: 0.05
+      shoulder_pan_joint: {trajectory: 0.1, goal: 0.1}
+      shoulder_lift_joint: {trajectory: 0.1, goal: 0.1}
+      elbow_joint: {trajectory: 0.1, goal: 0.1}
+      wrist_1_joint: {trajectory: 0.1, goal: 0.1}
+      wrist_2_joint: {trajectory: 0.1, goal: 0.1}
+      wrist_3_joint: {trajectory: 0.1, goal: 0.1}
+   stop_trajectory_duration: 0.5
+   state_publish_rate:  125
+   action_monitor_rate: 10
+   gains:
+      #!!These values have not been optimized!!
+      shoulder_pan_joint:  {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
+      shoulder_lift_joint: {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
+      elbow_joint:         {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
+      wrist_1_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
+      wrist_2_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
+      wrist_3_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
+
+   # Use a feedforward term to reduce the size of PID gains
+   velocity_ff:
+    shoulder_pan_joint: 1.0
+    shoulder_lift_joint: 1.0
+    elbow_joint: 1.0
+    wrist_1_joint: 1.0
+    wrist_2_joint: 1.0
+    wrist_3_joint: 1.0
+
+   # state_publish_rate:  50 # Defaults to 50
+   # action_monitor_rate: 20 # Defaults to 20
+   #stop_trajectory_duration: 0 # Defaults to 0.0
+
+# Pass an array of joint velocities directly to the joints
+joint_group_vel_controller:
+   type: velocity_controllers/JointGroupVelocityController
+   joints:
+     - shoulder_pan_joint
+     - shoulder_lift_joint
+     - elbow_joint
+     - wrist_1_joint
+     - wrist_2_joint
+     - wrist_3_joint

--- a/config/ur5e_controllers.yaml
+++ b/config/ur5e_controllers.yaml
@@ -1,0 +1,107 @@
+# Settings for ros_control control loop
+hardware_control_loop:
+   loop_hz: 125
+
+# Settings for ros_control hardware interface
+hardware_interface:
+   joints:
+     - shoulder_pan_joint
+     - shoulder_lift_joint
+     - elbow_joint
+     - wrist_1_joint
+     - wrist_2_joint
+     - wrist_3_joint
+
+# Publish all joint states ----------------------------------
+joint_state_controller:
+   type:         joint_state_controller/JointStateController
+   publish_rate: 125
+
+# Publish wrench ----------------------------------
+force_torque_sensor_controller:
+   type:         force_torque_sensor_controller/ForceTorqueSensorController
+   publish_rate: 125
+
+# Joint Trajectory Controller - position based -------------------------------
+# For detailed explanations of parameter see http://wiki.ros.org/joint_trajectory_controller
+pos_based_pos_traj_controller:
+   type: position_controllers/JointTrajectoryController
+   joints:
+     - shoulder_pan_joint
+     - shoulder_lift_joint
+     - elbow_joint
+     - wrist_1_joint
+     - wrist_2_joint
+     - wrist_3_joint
+   constraints:
+      goal_time: 0.6
+      stopped_velocity_tolerance: 0.05
+      shoulder_pan_joint: {trajectory: 0.1, goal: 0.1}
+      shoulder_lift_joint: {trajectory: 0.1, goal: 0.1}
+      elbow_joint: {trajectory: 0.1, goal: 0.1}
+      wrist_1_joint: {trajectory: 0.1, goal: 0.1}
+      wrist_2_joint: {trajectory: 0.1, goal: 0.1}
+      wrist_3_joint: {trajectory: 0.1, goal: 0.1}
+   stop_trajectory_duration: 0.5
+   state_publish_rate:  125
+   action_monitor_rate: 10
+
+   # state_publish_rate:  50 # Defaults to 50
+   # action_monitor_rate: 20 # Defaults to 20
+   #stop_trajectory_duration: 0 # Defaults to 0.0
+   
+# Joint Trajectory Controller - velocity based -------------------------------
+# For detailed explanations of parameter see http://wiki.ros.org/joint_trajectory_controller
+vel_based_pos_traj_controller:
+   type: velocity_controllers/JointTrajectoryController
+   joints:
+     - shoulder_pan_joint
+     - shoulder_lift_joint
+     - elbow_joint
+     - wrist_1_joint
+     - wrist_2_joint
+     - wrist_3_joint
+   constraints:
+      goal_time: 0.6
+      stopped_velocity_tolerance: 0.05
+      shoulder_pan_joint: {trajectory: 0.1, goal: 0.1}
+      shoulder_lift_joint: {trajectory: 0.1, goal: 0.1}
+      elbow_joint: {trajectory: 0.1, goal: 0.1}
+      wrist_1_joint: {trajectory: 0.1, goal: 0.1}
+      wrist_2_joint: {trajectory: 0.1, goal: 0.1}
+      wrist_3_joint: {trajectory: 0.1, goal: 0.1}
+   stop_trajectory_duration: 0.5
+   state_publish_rate:  125
+   action_monitor_rate: 10
+   gains:
+      #!!These values have not been optimized!!
+      shoulder_pan_joint:  {p: 1.2,  i: 0.01, d: 0.1, i_clamp: 1}
+      shoulder_lift_joint: {p: 1.2,  i: 0.01, d: 0.1, i_clamp: 1}
+      elbow_joint:         {p: 1.2,  i: 0.01, d: 0.1, i_clamp: 1}
+      wrist_1_joint:       {p: 1.2,  i: 0.01, d: 0.1, i_clamp: 1}
+      wrist_2_joint:       {p: 1.2,  i: 0.01, d: 0.1, i_clamp: 1}
+      wrist_3_joint:       {p: 1.2,  i: 0.01, d: 0.1, i_clamp: 1}
+
+   # Use a feedforward term to reduce the size of PID gains
+   velocity_ff:
+      shoulder_pan_joint: 1.0
+      shoulder_lift_joint: 1.0
+      elbow_joint: 1.0
+      wrist_1_joint: 1.0
+      wrist_2_joint: 1.0
+      wrist_3_joint: 1.0
+
+   # state_publish_rate:  50 # Defaults to 50
+   # action_monitor_rate: 20 # Defaults to 20
+   #stop_trajectory_duration: 0 # Defaults to 0.0
+
+# Pass an array of joint velocities directly to the joints
+joint_group_vel_controller:
+   type: velocity_controllers/JointGroupVelocityController
+   joints:
+     - shoulder_pan_joint
+     - shoulder_lift_joint
+     - elbow_joint
+     - wrist_1_joint
+     - wrist_2_joint
+     - wrist_3_joint

--- a/include/ur_modern_driver/event_counter.h
+++ b/include/ur_modern_driver/event_counter.h
@@ -88,6 +88,11 @@ public:
     trigger();
     return true;
   }
+  bool consume(RTState_V3_5__5_1& state)
+  {
+    trigger();
+    return true;
+  }
 
   void setupConsumer()
   {

--- a/include/ur_modern_driver/ros/action_server.h
+++ b/include/ur_modern_driver/ros/action_server.h
@@ -90,4 +90,5 @@ public:
   virtual bool consume(RTState_V1_8& state);
   virtual bool consume(RTState_V3_0__1& state);
   virtual bool consume(RTState_V3_2__3& state);
+  virtual bool consume(RTState_V3_5__5_1& state);
 };

--- a/include/ur_modern_driver/ros/controller.h
+++ b/include/ur_modern_driver/ros/controller.h
@@ -103,6 +103,11 @@ public:
     read(state);
     return update();
   }
+  virtual bool consume(RTState_V3_5__5_1& state)
+  {
+    read(state);
+    return update();
+  }
 
   virtual void onTimeout();
 

--- a/include/ur_modern_driver/ros/rt_publisher.h
+++ b/include/ur_modern_driver/ros/rt_publisher.h
@@ -79,6 +79,7 @@ public:
   virtual bool consume(RTState_V1_8& state);
   virtual bool consume(RTState_V3_0__1& state);
   virtual bool consume(RTState_V3_2__3& state);
+  virtual bool consume(RTState_V3_5__5_1& state);
 
   virtual void setupConsumer()
   {

--- a/include/ur_modern_driver/ur/consumer.h
+++ b/include/ur_modern_driver/ur/consumer.h
@@ -37,6 +37,7 @@ public:
   virtual bool consume(RTState_V1_8& state) = 0;
   virtual bool consume(RTState_V3_0__1& state) = 0;
   virtual bool consume(RTState_V3_2__3& state) = 0;
+  virtual bool consume(RTState_V3_5__5_1& state) = 0;
 };
 
 class URStatePacketConsumer : public IConsumer<StatePacket>

--- a/include/ur_modern_driver/ur/factory.h
+++ b/include/ur_modern_driver/ur/factory.h
@@ -110,7 +110,7 @@ public:
     {
       return std::unique_ptr<URParser<StatePacket>>(new URStateParser_V1_X);
     }
-    else
+    else if (major_version_ == 3)
     {
       if (minor_version_ < 3)
         return std::unique_ptr<URParser<StatePacket>>(new URStateParser_V3_0__1);
@@ -118,6 +118,10 @@ public:
         return std::unique_ptr<URParser<StatePacket>>(new URStateParser_V3_2);
       else
         return std::unique_ptr<URParser<StatePacket>>(new URStateParser_V3_5);
+    }
+    else
+    {
+      return std::unique_ptr<URParser<StatePacket>>(new URStateParser_V3_5);
     }
   }
 
@@ -130,12 +134,18 @@ public:
       else
         return std::unique_ptr<URParser<RTPacket>>(new URRTStateParser_V1_8);
     }
+    else if (major_version_ == 3)
+    {
+      if (minor_version_ < 2)
+        return std::unique_ptr<URParser<RTPacket>>(new URRTStateParser_V3_0__1);
+      else if (minor_version_ < 5)
+        return std::unique_ptr<URParser<RTPacket>>(new URRTStateParser_V3_2__3);
+      else
+        return std::unique_ptr<URParser<RTPacket>>(new URRTStateParser_V3_5__5_1);
+    }
     else
     {
-      if (minor_version_ < 3)
-        return std::unique_ptr<URParser<RTPacket>>(new URRTStateParser_V3_0__1);
-      else
-        return std::unique_ptr<URParser<RTPacket>>(new URRTStateParser_V3_2__3);
+      return std::unique_ptr<URParser<RTPacket>>(new URRTStateParser_V3_5__5_1);
     }
   }
 };

--- a/include/ur_modern_driver/ur/rt_parser.h
+++ b/include/ur_modern_driver/ur/rt_parser.h
@@ -54,3 +54,4 @@ typedef URRTStateParser<RTState_V1_6__7> URRTStateParser_V1_6__7;
 typedef URRTStateParser<RTState_V1_8> URRTStateParser_V1_8;
 typedef URRTStateParser<RTState_V3_0__1> URRTStateParser_V3_0__1;
 typedef URRTStateParser<RTState_V3_2__3> URRTStateParser_V3_2__3;
+typedef URRTStateParser<RTState_V3_5__5_1> URRTStateParser_V3_5__5_1;

--- a/include/ur_modern_driver/ur/rt_state.h
+++ b/include/ur_modern_driver/ur/rt_state.h
@@ -135,3 +135,17 @@ public:
 
   static_assert(RTState_V3_2__3::SIZE == 936, "RTState_V3_2__3 has mismatched size!");
 };
+
+class RTState_V3_5__5_1 : public RTState_V3_2__3
+{
+public:
+  bool parseWith(BinParser& bp);
+  virtual bool consumeWith(URRTPacketConsumer& consumer);
+
+  double3_t elbow_position;
+  double3_t elbow_velocity;
+
+  static const size_t SIZE = RTState_V3_2__3::SIZE + sizeof(double3_t) * 2;
+
+  static_assert(RTState_V3_5__5_1::SIZE == 984, "RTState_V3_5__5_1 has mismatched size!");
+};

--- a/launch/ur10e_bringup.launch
+++ b/launch/ur10e_bringup.launch
@@ -1,0 +1,56 @@
+<?xml version="1.0"?>
+<!--
+  Universal robot ur10e launch.  Loads ur10e robot description (see ur_common.launch
+  for more info)
+
+  Usage:
+    ur10e_bringup.launch robot_ip:=<value>
+-->
+<launch>
+
+  <!-- robot_ip: IP-address of the robot's socket-messaging server -->
+  <arg name="robot_ip" doc="IP of the controller" />
+  <arg name="reverse_ip" default="" doc="IP of the computer running the driver" />
+  <arg name="reverse_port" default="50001"/>
+  <arg name="limited" default="false"/>
+  <arg name="min_payload"  default="0.0"/>
+  <arg name="max_payload"  default="10.0"/>
+  <arg name="prefix" default="" />
+  <arg name="use_lowbandwidth_trajectory_follower" default="false"/>
+  <arg name="time_interval" default="0.008"/>
+  <arg name="servoj_time" default="0.008" />
+  <arg name="servoj_time_waiting" default="0.001" />
+  <arg name="max_waiting_time" default="2.0" />
+  <arg name="servoj_gain" default="100." />
+  <arg name="servoj_lookahead_time" default="1." />
+  <arg name="max_joint_difference" default="0.01" />
+  <arg name="base_frame" default="$(arg prefix)base" />
+  <arg name="tool_frame" default="$(arg prefix)tool0_controller" />
+  <arg name="shutdown_on_disconnect" default="true" />
+  <!-- robot model -->
+  <include file="$(find ur_e_description)/launch/ur10e_upload.launch">
+    <arg name="limited" value="$(arg limited)"/>
+  </include>
+
+  <!-- ur common -->
+  <include file="$(find ur_modern_driver)/launch/ur_common.launch">
+    <arg name="robot_ip" value="$(arg robot_ip)"/>
+    <arg name="reverse_ip" value="$(arg reverse_ip)"/>
+    <arg name="reverse_port" value="$(arg reverse_port)"/>
+    <arg name="min_payload"  value="$(arg min_payload)"/>
+    <arg name="max_payload"  value="$(arg max_payload)"/>
+    <arg name="prefix" default="" />
+    <arg name="use_lowbandwidth_trajectory_follower" value="$(arg use_lowbandwidth_trajectory_follower)"/>
+    <arg name="time_interval" value="$(arg time_interval)"/>
+    <arg name="servoj_time" value="$(arg servoj_time)" />
+    <arg name="servoj_time_waiting" default="$(arg servoj_time_waiting)" />
+    <arg name="max_waiting_time" value="$(arg max_waiting_time)" />
+    <arg name="servoj_gain" value="$(arg servoj_gain)" />
+    <arg name="servoj_lookahead_time" value="$(arg servoj_lookahead_time)" />
+    <arg name="max_joint_difference" value="$(arg max_joint_difference)" />
+    <arg name="base_frame" value="$(arg base_frame)" />
+    <arg name="tool_frame" value="$(arg tool_frame)" />
+    <arg name="shutdown_on_disconnect" value="$(arg shutdown_on_disconnect)"/>
+  </include>
+
+</launch>

--- a/launch/ur10e_bringup_compatible.launch
+++ b/launch/ur10e_bringup_compatible.launch
@@ -1,0 +1,57 @@
+<?xml version="1.0"?>
+<!--
+  Universal robot ur10e launch.  Loads ur10e robot description (see ur_common.launch
+  for more info)
+
+  Usage:
+    ur10e_bringup.launch robot_ip:=<value>
+-->
+<launch>
+
+  <!-- robot_ip: IP-address of the robot's socket-messaging server -->
+  <arg name="robot_ip" doc="IP of the controller" />
+  <arg name="reverse_ip" default="" doc="IP of the computer running the driver" />
+  <arg name="reverse_port" default="50001"/>
+  <arg name="limited" default="false"/>
+  <arg name="min_payload"  default="0.0"/>
+  <arg name="max_payload"  default="10.0"/>
+  <arg name="prefix" default="" />
+  <arg name="use_lowbandwidth_trajectory_follower" default="false"/>
+  <arg name="time_interval" default="0.08"/>
+  <arg name="servoj_time" default="0.08" />
+  <arg name="servoj_time_waiting" default="0.001" />
+  <arg name="max_waiting_time" default="2.0" />
+  <arg name="servoj_gain" default="100." />
+  <arg name="servoj_lookahead_time" default="1." />
+  <arg name="max_joint_difference" default="0.01" />
+  <arg name="base_frame" default="$(arg prefix)base" />
+  <arg name="tool_frame" default="$(arg prefix)tool0_controller" />
+  <arg name="shutdown_on_disconnect" default="true" />
+
+  <!-- robot model -->
+  <include file="$(find ur_e_description)/launch/ur10e_upload.launch">
+    <arg name="limited" value="$(arg limited)"/>
+  </include>
+
+  <!-- ur common -->
+  <include file="$(find ur_modern_driver)/launch/ur_common.launch">
+    <arg name="robot_ip" value="$(arg robot_ip)"/>
+    <arg name="reverse_ip" value="$(arg reverse_ip)"/>
+    <arg name="reverse_port" value="$(arg reverse_port)"/>
+    <arg name="min_payload"  value="$(arg min_payload)"/>
+    <arg name="max_payload"  value="$(arg max_payload)"/>
+    <arg name="prefix" default="" />
+    <arg name="use_lowbandwidth_trajectory_follower" value="$(arg use_lowbandwidth_trajectory_follower)"/>
+    <arg name="time_interval" value="$(arg time_interval)"/>
+    <arg name="servoj_time" value="$(arg servoj_time)" />
+    <arg name="servoj_time_waiting" default="$(arg servoj_time_waiting)" />
+    <arg name="max_waiting_time" value="$(arg max_waiting_time)" />
+    <arg name="servoj_gain" value="$(arg servoj_gain)" />
+    <arg name="servoj_lookahead_time" value="$(arg servoj_lookahead_time)" />
+    <arg name="max_joint_difference" value="$(arg max_joint_difference)" />
+    <arg name="base_frame" value="$(arg base_frame)" />
+    <arg name="tool_frame" value="$(arg tool_frame)" />
+    <arg name="shutdown_on_disconnect" value="$(arg shutdown_on_disconnect)"/>
+  </include>
+
+</launch>

--- a/launch/ur10e_bringup_joint_limited.launch
+++ b/launch/ur10e_bringup_joint_limited.launch
@@ -1,0 +1,50 @@
+<?xml version="1.0"?>
+<!--
+  Universal robot ur10e launch. Wraps ur10e_bringup.launch. Uses the 'limited'
+  joint range [-PI, PI] on all joints.
+
+  Usage:
+    ur10e_bringup_joint_limited.launch robot_ip:=<value>
+-->
+<launch>
+
+  <!-- robot_ip: IP-address of the robot's socket-messaging server -->
+  <arg name="robot_ip" doc="IP of the controller" />
+  <arg name="reverse_ip" default="" doc="IP of the computer running the driver" />
+  <arg name="reverse_port" default="50001"/>
+  <arg name="min_payload"  default="0.0"/>
+  <arg name="max_payload"  default="10.0"/>
+  <arg name="prefix" default="" />
+  <arg name="use_lowbandwidth_trajectory_follower" default="false"/>
+  <arg name="time_interval" default="0.008"/>
+  <arg name="servoj_time" default="0.008" />
+  <arg name="servoj_time_waiting" default="0.001" />
+  <arg name="max_waiting_time" default="2.0" />
+  <arg name="servoj_gain" default="100." />
+  <arg name="servoj_lookahead_time" default="1." />
+  <arg name="max_joint_difference" default="0.01" />
+  <arg name="base_frame" default="$(arg prefix)base" />
+  <arg name="tool_frame" default="$(arg prefix)tool0_controller" />
+  <arg name="shutdown_on_disconnect" default="true" />
+
+  <include file="$(find ur_modern_driver)/launch/ur10e_bringup.launch">
+    <arg name="robot_ip" value="$(arg robot_ip)"/>
+    <arg name="reverse_ip" value="$(arg reverse_ip)"/>
+    <arg name="reverse_port" value="$(arg reverse_port)"/>
+    <arg name="limited"  value="true"/>
+    <arg name="min_payload"  value="$(arg min_payload)"/>
+    <arg name="max_payload"  value="$(arg max_payload)"/>
+    <arg name="prefix" value="$(arg prefix)" />
+    <arg name="use_lowbandwidth_trajectory_follower" value="$(arg use_lowbandwidth_trajectory_follower)"/>
+    <arg name="time_interval" value="$(arg time_interval)"/>
+    <arg name="servoj_time" value="$(arg servoj_time)" />
+    <arg name="servoj_time_waiting" default="$(arg servoj_time_waiting)" />
+    <arg name="max_waiting_time" value="$(arg max_waiting_time)" />
+    <arg name="servoj_gain" value="$(arg servoj_gain)" />
+    <arg name="servoj_lookahead_time" value="$(arg servoj_lookahead_time)" />
+    <arg name="max_joint_difference" value="$(arg max_joint_difference)" />
+    <arg name="base_frame" value="$(arg base_frame)" />
+    <arg name="tool_frame" value="$(arg tool_frame)" />
+    <arg name="shutdown_on_disconnect" value="$(arg shutdown_on_disconnect)"/>
+  </include>
+</launch>

--- a/launch/ur10e_ros_control.launch
+++ b/launch/ur10e_ros_control.launch
@@ -1,0 +1,58 @@
+<?xml version="1.0"?>
+<launch>
+
+  <!-- GDB functionality -->
+  <arg name="debug" default="false" />
+  <arg unless="$(arg debug)" name="launch_prefix" value="" />
+  <arg     if="$(arg debug)" name="launch_prefix" value="gdb --ex run --args" />
+
+  <arg name="robot_ip" doc="IP of the controller" />
+  <arg name="reverse_ip" default="" doc="IP of the computer running the driver" />
+  <arg name="reverse_port" default="50001"/>
+  <arg name="limited" default="false"/>
+  <arg name="min_payload"  default="0.0"/>
+  <arg name="max_payload"  default="3.0"/>
+  <arg name="prefix" default="" />
+  <arg name="max_velocity" default="10.0"/> <!-- [rad/s] -->
+  <arg name="base_frame" default="$(arg prefix)base" />
+  <arg name="tool_frame" default="$(arg prefix)tool0_controller" />
+  <arg name="shutdown_on_disconnect" default="true" />
+  <arg name="controllers" default="joint_state_controller force_torque_sensor_controller vel_based_pos_traj_controller"/>
+  <arg name="stopped_controllers" default="pos_based_pos_traj_controller joint_group_vel_controller"/>
+  <!-- robot model -->
+  <include file="$(find ur_e_description)/launch/ur10e_upload.launch">
+    <arg name="limited" value="$(arg limited)"/>
+  </include>
+
+
+  <!-- Load hardware interface -->
+  <node name="ur_hardware_interface" pkg="ur_modern_driver" type="ur_driver" output="log" launch-prefix="$(arg launch_prefix)">
+    <param name="robot_ip_address" type="str" value="$(arg robot_ip)"/>
+    <param name="reverse_ip_address" type="str" value="$(arg reverse_ip)" />
+    <param name="reverse_port" type="int" value="$(arg reverse_port)" />
+    <param name="min_payload" type="double" value="$(arg min_payload)"/>
+    <param name="max_payload" type="double" value="$(arg max_payload)"/>
+    <param name="max_velocity" type="double" value="$(arg max_velocity)"/>
+    <param name="use_ros_control" type="bool" value="True"/>
+    <param name="servoj_gain" type="double" value="750" />
+    <param name="prefix" value="$(arg prefix)" />
+    <param name="base_frame" type="str" value="$(arg base_frame)"/>
+    <param name="tool_frame" type="str" value="$(arg tool_frame)"/>
+    <param name="shutdown_on_disconnect" type="bool" value="$(arg shutdown_on_disconnect)"/>
+  </node>
+
+  <!-- Load controller settings -->
+  <rosparam file="$(find ur_modern_driver)/config/ur10e_controllers.yaml" command="load"/>
+
+  <!-- spawn controller manager -->
+  <node name="ros_control_controller_spawner" pkg="controller_manager" type="spawner" respawn="false"
+    output="screen" args="$(arg controllers)" />
+
+  <!-- load other controller -->
+  <node name="ros_control_controller_manager" pkg="controller_manager" type="controller_manager" respawn="false"
+    output="screen" args="load $(arg stopped_controllers)" />
+
+  <!-- Convert joint states to /tf tranforms -->
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>
+
+</launch>

--- a/launch/ur3e_bringup.launch
+++ b/launch/ur3e_bringup.launch
@@ -1,0 +1,56 @@
+<?xml version="1.0"?>
+<!--
+  Universal robot ur3e launch.  Loads ur3e robot description (see ur_common.launch
+  for more info)
+
+  Usage:
+    ur3e_bringup.launch robot_ip:=<value>
+-->
+<launch>
+
+  <!-- robot_ip: IP-address of the robot's socket-messaging server -->
+  <arg name="robot_ip" doc="IP of the controller" />
+  <arg name="reverse_ip" default="" doc="IP of the computer running the driver" />
+  <arg name="reverse_port" default="50001"/>
+  <arg name="limited" default="false"/>
+  <arg name="min_payload"  default="0.0"/>
+  <arg name="max_payload"  default="3.0"/>
+  <arg name="prefix" default="" />
+  <arg name="use_lowbandwidth_trajectory_follower" default="false"/>
+  <arg name="time_interval" default="0.008"/>
+  <arg name="servoj_time" default="0.008" />
+  <arg name="servoj_time_waiting" default="0.001" />
+  <arg name="max_waiting_time" default="2.0" />
+  <arg name="servoj_gain" default="100." />
+  <arg name="servoj_lookahead_time" default="1." />
+  <arg name="max_joint_difference" default="0.01" />
+  <arg name="base_frame" default="$(arg prefix)base" />
+  <arg name="tool_frame" default="$(arg prefix)tool0_controller" />
+  <arg name="shutdown_on_disconnect" default="true" />
+  <!-- robot model -->
+  <include file="$(find ur_e_description)/launch/ur3e_upload.launch">
+    <arg name="limited" value="$(arg limited)"/>
+  </include>
+
+  <!-- ur common -->
+  <include file="$(find ur_modern_driver)/launch/ur_common.launch">
+    <arg name="robot_ip" value="$(arg robot_ip)"/>
+    <arg name="reverse_ip" value="$(arg reverse_ip)"/>
+    <arg name="reverse_port" value="$(arg reverse_port)"/>
+    <arg name="min_payload"  value="$(arg min_payload)"/>
+    <arg name="max_payload"  value="$(arg max_payload)"/>
+    <arg name="prefix" value="$(arg prefix)" />
+    <arg name="use_lowbandwidth_trajectory_follower" value="$(arg use_lowbandwidth_trajectory_follower)"/>
+    <arg name="time_interval" value="$(arg time_interval)"/>
+    <arg name="servoj_time" value="$(arg servoj_time)" />
+    <arg name="servoj_time_waiting" default="$(arg servoj_time_waiting)" />
+    <arg name="max_waiting_time" value="$(arg max_waiting_time)" />
+    <arg name="servoj_gain" value="$(arg servoj_gain)" />
+    <arg name="servoj_lookahead_time" value="$(arg servoj_lookahead_time)" />
+    <arg name="max_joint_difference" value="$(arg max_joint_difference)" />
+    <arg name="base_frame" value="$(arg base_frame)" />
+    <arg name="tool_frame" value="$(arg tool_frame)" />
+    <arg name="shutdown_on_disconnect" value="$(arg shutdown_on_disconnect)"/>
+  </include>
+
+</launch>

--- a/launch/ur3e_bringup_joint_limited.launch
+++ b/launch/ur3e_bringup_joint_limited.launch
@@ -1,0 +1,50 @@
+<?xml version="1.0"?>
+<!--
+  Universal robot ur3e launch. Wraps ur3e_bringup.launch. Uses the 'limited'
+  joint range [-PI, PI] on all joints.
+
+  Usage:
+    ur3e_bringup_joint_limited.launch robot_ip:=<value>
+-->
+<launch>
+
+  <!-- robot_ip: IP-address of the robot's socket-messaging server -->
+  <arg name="robot_ip" doc="IP of the controller" />
+  <arg name="reverse_ip" default="" doc="IP of the computer running the driver" />
+  <arg name="reverse_port" default="50001"/>
+  <arg name="min_payload"  default="0.0"/>
+  <arg name="max_payload"  default="3.0"/>
+  <arg name="prefix" default="" />
+  <arg name="use_lowbandwidth_trajectory_follower" default="false"/>
+  <arg name="time_interval" default="0.008"/>
+  <arg name="servoj_time" default="0.008" />
+  <arg name="servoj_time_waiting" default="0.001" />
+  <arg name="max_waiting_time" default="2.0" />
+  <arg name="servoj_gain" default="100." />
+  <arg name="servoj_lookahead_time" default="1." />
+  <arg name="max_joint_difference" default="0.01" />
+  <arg name="base_frame" default="$(arg prefix)base" />
+  <arg name="tool_frame" default="$(arg prefix)tool0_controller" />
+  <arg name="shutdown_on_disconnect" default="true" />
+
+  <include file="$(find ur_modern_driver)/launch/ur3e_bringup.launch">
+    <arg name="robot_ip" value="$(arg robot_ip)"/>
+    <arg name="reverse_ip" value="$(arg reverse_ip)"/>
+    <arg name="reverse_port" value="$(arg reverse_port)"/>
+    <arg name="limited"  value="true"/>
+    <arg name="min_payload"  value="$(arg min_payload)"/>
+    <arg name="max_payload"  value="$(arg max_payload)"/>
+    <arg name="prefix" value="$(arg prefix)" />
+    <arg name="use_lowbandwidth_trajectory_follower" value="$(arg use_lowbandwidth_trajectory_follower)"/>
+    <arg name="time_interval" value="$(arg time_interval)"/>
+    <arg name="servoj_time" value="$(arg servoj_time)" />
+    <arg name="servoj_time_waiting" default="$(arg servoj_time_waiting)" />
+    <arg name="max_waiting_time" value="$(arg max_waiting_time)" />
+    <arg name="servoj_gain" value="$(arg servoj_gain)" />
+    <arg name="servoj_lookahead_time" value="$(arg servoj_lookahead_time)" />
+    <arg name="max_joint_difference" value="$(arg max_joint_difference)" />
+    <arg name="base_frame" value="$(arg base_frame)" />
+    <arg name="tool_frame" value="$(arg tool_frame)" />
+    <arg name="shutdown_on_disconnect" value="$(arg shutdown_on_disconnect)"/>
+  </include>
+</launch>

--- a/launch/ur3e_ros_control.launch
+++ b/launch/ur3e_ros_control.launch
@@ -1,0 +1,58 @@
+<?xml version="1.0"?>
+<launch>
+
+  <!-- GDB functionality -->
+  <arg name="debug" default="false" />
+  <arg unless="$(arg debug)" name="launch_prefix" value="" />
+  <arg     if="$(arg debug)" name="launch_prefix" value="gdb --ex run --args" />
+
+  <arg name="robot_ip" doc="IP of the controller" />
+  <arg name="reverse_ip" default="" doc="IP of the computer running the driver" />
+  <arg name="reverse_port" default="50001"/>
+  <arg name="limited" default="false"/>
+  <arg name="min_payload"  default="0.0"/>
+  <arg name="max_payload"  default="3.0"/>
+  <arg name="prefix" default="" />
+  <arg name="max_velocity" default="10.0"/> <!-- [rad/s] -->
+  <arg name="base_frame" default="$(arg prefix)base" />
+  <arg name="tool_frame" default="$(arg prefix)tool0_controller" />
+  <arg name="shutdown_on_disconnect" default="true" />
+  <arg name="controllers" default="joint_state_controller force_torque_sensor_controller vel_based_pos_traj_controller"/>
+  <arg name="stopped_controllers" default="pos_based_pos_traj_controller joint_group_vel_controller"/>
+  <!-- robot model -->
+  <include file="$(find ur_e_description)/launch/ur3e_upload.launch">
+    <arg name="limited" value="$(arg limited)"/>
+  </include>
+
+
+  <!-- Load hardware interface -->
+  <node name="ur_hardware_interface" pkg="ur_modern_driver" type="ur_driver" output="log" launch-prefix="$(arg launch_prefix)">
+    <param name="robot_ip_address" type="str" value="$(arg robot_ip)"/>
+    <param name="reverse_ip_address" type="str" value="$(arg reverse_ip)" />
+    <param name="reverse_port" type="int" value="$(arg reverse_port)" />
+    <param name="min_payload" type="double" value="$(arg min_payload)"/>
+    <param name="max_payload" type="double" value="$(arg max_payload)"/>
+    <param name="max_velocity" type="double" value="$(arg max_velocity)"/>
+    <param name="use_ros_control" type="bool" value="True"/>
+    <param name="servoj_gain" type="double" value="750" />
+    <param name="prefix" value="$(arg prefix)" />
+    <param name="base_frame" type="str" value="$(arg base_frame)"/>
+    <param name="tool_frame" type="str" value="$(arg tool_frame)"/>
+    <param name="shutdown_on_disconnect" type="bool" value="$(arg shutdown_on_disconnect)"/>
+  </node>
+
+  <!-- Load controller settings -->
+  <rosparam file="$(find ur_modern_driver)/config/ur3e_controllers.yaml" command="load"/>
+
+  <!-- spawn controller manager -->
+  <node name="ros_control_controller_spawner" pkg="controller_manager" type="spawner" respawn="false"
+    output="screen" args="$(arg controllers)" />
+
+  <!-- load other controller -->
+  <node name="ros_control_controller_manager" pkg="controller_manager" type="controller_manager" respawn="false"
+    output="screen" args="load $(arg stopped_controllers)" />
+
+  <!-- Convert joint states to /tf tranforms -->
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>
+
+</launch>

--- a/launch/ur5e_bringup.launch
+++ b/launch/ur5e_bringup.launch
@@ -1,0 +1,56 @@
+<?xml version="1.0"?>
+<!--
+  Universal robot ur5e launch.  Loads ur5e robot description (see ur_common.launch
+  for more info)
+
+  Usage:
+    ur5e_bringup.launch robot_ip:=<value>
+-->
+<launch>
+
+  <!-- robot_ip: IP-address of the robot's socket-messaging server -->
+  <arg name="robot_ip" doc="IP of the controller" />
+  <arg name="reverse_ip" default="" doc="IP of the computer running the driver" />
+  <arg name="reverse_port" default="50001"/>
+  <arg name="limited" default="false"/>
+  <arg name="min_payload"  default="0.0"/>
+  <arg name="max_payload"  default="5.0"/>
+  <arg name="prefix" default="" />
+  <arg name="use_lowbandwidth_trajectory_follower" default="false"/>
+  <arg name="time_interval" default="0.008"/>
+  <arg name="servoj_time" default="0.008" />
+  <arg name="servoj_time_waiting" default="0.001" />
+  <arg name="max_waiting_time" default="2.0" />
+  <arg name="servoj_gain" default="100." />
+  <arg name="servoj_lookahead_time" default="1." />
+  <arg name="max_joint_difference" default="0.01" />
+  <arg name="base_frame" default="$(arg prefix)base" />
+  <arg name="tool_frame" default="$(arg prefix)tool0_controller" />
+  <arg name="shutdown_on_disconnect" default="true" />
+  <!-- robot model -->
+  <include file="$(find ur_e_description)/launch/ur5e_upload.launch">
+    <arg name="limited" value="$(arg limited)"/>
+  </include>
+
+  <!-- ur common -->
+  <include file="$(find ur_modern_driver)/launch/ur_common.launch">
+    <arg name="robot_ip" value="$(arg robot_ip)"/>
+    <arg name="reverse_ip" value="$(arg reverse_ip)"/>
+    <arg name="reverse_port" value="$(arg reverse_port)"/>
+    <arg name="min_payload"  value="$(arg min_payload)"/>
+    <arg name="max_payload"  value="$(arg max_payload)"/>
+    <arg name="prefix"  value="$(arg prefix)" />
+    <arg name="use_lowbandwidth_trajectory_follower" value="$(arg use_lowbandwidth_trajectory_follower)"/>
+    <arg name="time_interval" value="$(arg time_interval)"/>
+    <arg name="servoj_time" value="$(arg servoj_time)" />
+    <arg name="servoj_time_waiting" default="$(arg servoj_time_waiting)" />
+    <arg name="max_waiting_time" value="$(arg max_waiting_time)" />
+    <arg name="servoj_gain" value="$(arg servoj_gain)" />
+    <arg name="servoj_lookahead_time" value="$(arg servoj_lookahead_time)" />
+    <arg name="max_joint_difference" value="$(arg max_joint_difference)" />
+    <arg name="base_frame" value="$(arg base_frame)" />
+    <arg name="tool_frame" value="$(arg tool_frame)" />
+    <arg name="shutdown_on_disconnect" value="$(arg shutdown_on_disconnect)"/>
+  </include>
+
+</launch>

--- a/launch/ur5e_bringup_compatible.launch
+++ b/launch/ur5e_bringup_compatible.launch
@@ -1,0 +1,57 @@
+<?xml version="1.0"?>
+<!--
+  Universal robot ur5e launch.  Loads ur5e robot description (see ur_common.launch
+  for more info)
+
+  Usage:
+    ur5e_bringup.launch robot_ip:=<value>
+-->
+<launch>
+
+  <!-- robot_ip: IP-address of the robot's socket-messaging server -->
+  <arg name="robot_ip" doc="IP of the controller" />
+  <arg name="reverse_ip" default="" doc="IP of the computer running the driver" />
+  <arg name="reverse_port" default="50001"/>
+  <arg name="limited" default="false"/>
+  <arg name="min_payload"  default="0.0"/>
+  <arg name="max_payload"  default="5.0"/>
+  <arg name="prefix" default="" />
+  <arg name="use_lowbandwidth_trajectory_follower" default="false"/>
+  <arg name="time_interval" default="0.08"/>
+  <arg name="servoj_time" default="0.08" />
+  <arg name="servoj_time_waiting" default="0.001" />
+  <arg name="max_waiting_time" default="2.0" />
+  <arg name="servoj_gain" default="100." />
+  <arg name="servoj_lookahead_time" default="1." />
+  <arg name="max_joint_difference" default="0.01" />
+  <arg name="base_frame" default="$(arg prefix)base" />
+  <arg name="tool_frame" default="$(arg prefix)tool0_controller" />
+  <arg name="shutdown_on_disconnect" default="true" />
+
+  <!-- robot model -->
+  <include file="$(find ur_e_description)/launch/ur5e_upload.launch">
+    <arg name="limited" value="$(arg limited)"/>
+  </include>
+
+  <!-- ur common -->
+  <include file="$(find ur_modern_driver)/launch/ur_common.launch">
+    <arg name="robot_ip" value="$(arg robot_ip)"/>
+    <arg name="reverse_ip" value="$(arg reverse_ip)"/>
+    <arg name="reverse_port" value="$(arg reverse_port)"/>
+    <arg name="min_payload"  value="$(arg min_payload)"/>
+    <arg name="max_payload"  value="$(arg max_payload)"/>
+    <arg name="prefix"  value="$(arg prefix)" />
+    <arg name="use_lowbandwidth_trajectory_follower" value="$(arg use_lowbandwidth_trajectory_follower)"/>
+    <arg name="time_interval" value="$(arg time_interval)"/>
+    <arg name="servoj_time" value="$(arg servoj_time)" />
+    <arg name="servoj_time_waiting" default="$(arg servoj_time_waiting)" />
+    <arg name="max_waiting_time" value="$(arg max_waiting_time)" />
+    <arg name="servoj_gain" value="$(arg servoj_gain)" />
+    <arg name="servoj_lookahead_time" value="$(arg servoj_lookahead_time)" />
+    <arg name="max_joint_difference" value="$(arg max_joint_difference)" />
+    <arg name="base_frame" value="$(arg base_frame)" />
+    <arg name="tool_frame" value="$(arg tool_frame)" />
+    <arg name="shutdown_on_disconnect" value="$(arg shutdown_on_disconnect)"/>
+  </include>
+
+</launch>

--- a/launch/ur5e_bringup_joint_limited.launch
+++ b/launch/ur5e_bringup_joint_limited.launch
@@ -1,0 +1,50 @@
+<?xml version="1.0"?>
+<!--
+  Universal robot ur5e launch. Wraps ur5e_bringup.launch. Uses the 'limited'
+  joint range [-PI, PI] on all joints.
+
+  Usage:
+    ur5e_bringup_joint_limited.launch robot_ip:=<value>
+-->
+<launch>
+
+  <!-- robot_ip: IP-address of the robot's socket-messaging server -->
+  <arg name="robot_ip" doc="IP of the controller" />
+  <arg name="reverse_ip" default="" doc="IP of the computer running the driver" />
+  <arg name="reverse_port" default="50001"/>
+  <arg name="min_payload"  default="0.0"/>
+  <arg name="max_payload"  default="5.0"/>
+  <arg name="prefix" default="" />
+  <arg name="use_lowbandwidth_trajectory_follower" default="false"/>
+  <arg name="time_interval" default="0.008"/>
+  <arg name="servoj_time" default="0.008" />
+  <arg name="servoj_time_waiting" default="0.001" />
+  <arg name="max_waiting_time" default="2.0" />
+  <arg name="servoj_gain" default="100." />
+  <arg name="servoj_lookahead_time" default="1." />
+  <arg name="max_joint_difference" default="0.01" />
+  <arg name="base_frame" default="$(arg prefix)base" />
+  <arg name="tool_frame" default="$(arg prefix)tool0_controller" />
+  <arg name="shutdown_on_disconnect" default="true" />
+
+  <include file="$(find ur_modern_driver)/launch/ur5e_bringup.launch">
+    <arg name="robot_ip" value="$(arg robot_ip)"/>
+    <arg name="reverse_ip" value="$(arg reverse_ip)"/>
+    <arg name="reverse_port" value="$(arg reverse_port)"/>
+    <arg name="limited"  value="true"/>
+    <arg name="min_payload"  value="$(arg min_payload)"/>
+    <arg name="max_payload"  value="$(arg max_payload)"/>
+    <arg name="prefix" value="$(arg prefix)" />
+    <arg name="use_lowbandwidth_trajectory_follower" value="$(arg use_lowbandwidth_trajectory_follower)"/>
+    <arg name="time_interval" value="$(arg time_interval)"/>
+    <arg name="servoj_time" value="$(arg servoj_time)" />
+    <arg name="servoj_time_waiting" default="$(arg servoj_time_waiting)" />
+    <arg name="max_waiting_time" value="$(arg max_waiting_time)" />
+    <arg name="servoj_gain" value="$(arg servoj_gain)" />
+    <arg name="servoj_lookahead_time" value="$(arg servoj_lookahead_time)" />
+    <arg name="max_joint_difference" value="$(arg max_joint_difference)" />
+    <arg name="base_frame" value="$(arg base_frame)" />
+    <arg name="tool_frame" value="$(arg tool_frame)" />
+    <arg name="shutdown_on_disconnect" value="$(arg shutdown_on_disconnect)"/>
+  </include>
+</launch>

--- a/launch/ur5e_ros_control.launch
+++ b/launch/ur5e_ros_control.launch
@@ -1,0 +1,58 @@
+<?xml version="1.0"?>
+<launch>
+
+  <!-- GDB functionality -->
+  <arg name="debug" default="false" />
+  <arg unless="$(arg debug)" name="launch_prefix" value="" />
+  <arg     if="$(arg debug)" name="launch_prefix" value="gdb --ex run --args" />
+
+  <arg name="robot_ip" doc="IP of the controller" />
+  <arg name="reverse_ip" default="" doc="IP of the computer running the driver" />
+  <arg name="reverse_port" default="50001"/>
+  <arg name="limited" default="false"/>
+  <arg name="min_payload"  default="0.0"/>
+  <arg name="max_payload"  default="3.0"/>
+  <arg name="prefix" default="" />
+  <arg name="max_velocity" default="10.0"/> <!-- [rad/s] -->
+  <arg name="base_frame" default="$(arg prefix)base" />
+  <arg name="tool_frame" default="$(arg prefix)tool0_controller" />
+  <arg name="shutdown_on_disconnect" default="true" />
+  <arg name="controllers" default="joint_state_controller force_torque_sensor_controller vel_based_pos_traj_controller"/>
+  <arg name="stopped_controllers" default="pos_based_pos_traj_controller joint_group_vel_controller"/>
+  <!-- robot model -->
+  <include file="$(find ur_e_description)/launch/ur5e_upload.launch">
+    <arg name="limited" value="$(arg limited)"/>
+  </include>
+
+
+  <!-- Load hardware interface -->
+  <node name="ur_hardware_interface" pkg="ur_modern_driver" type="ur_driver" output="log" launch-prefix="$(arg launch_prefix)">
+    <param name="robot_ip_address" type="str" value="$(arg robot_ip)"/>
+    <param name="reverse_ip_address" type="str" value="$(arg reverse_ip)" />
+    <param name="reverse_port" type="int" value="$(arg reverse_port)" />
+    <param name="min_payload" type="double" value="$(arg min_payload)"/>
+    <param name="max_payload" type="double" value="$(arg max_payload)"/>
+    <param name="max_velocity" type="double" value="$(arg max_velocity)"/>
+    <param name="use_ros_control" type="bool" value="True"/>
+    <param name="servoj_gain" type="double" value="750" />
+    <param name="prefix" value="$(arg prefix)" />
+    <param name="base_frame" type="str" value="$(arg base_frame)"/>
+    <param name="tool_frame" type="str" value="$(arg tool_frame)"/>
+    <param name="shutdown_on_disconnect" type="bool" value="$(arg shutdown_on_disconnect)"/>
+  </node>
+
+  <!-- Load controller settings -->
+  <rosparam file="$(find ur_modern_driver)/config/ur5e_controllers.yaml" command="load"/>
+
+  <!-- spawn controller manager -->
+  <node name="ros_control_controller_spawner" pkg="controller_manager" type="spawner" respawn="false"
+    output="screen" args="$(arg controllers)" />
+
+  <!-- load other controller -->
+  <node name="ros_control_controller_manager" pkg="controller_manager" type="controller_manager" respawn="false"
+    output="screen" args="load $(arg stopped_controllers)" />
+
+  <!-- Convert joint states to /tf tranforms -->
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>
+
+</launch>

--- a/package.xml
+++ b/package.xml
@@ -36,6 +36,7 @@
   <exec_depend>joint_state_controller</exec_depend>
   <exec_depend>joint_trajectory_controller</exec_depend>
   <exec_depend>ur_description</exec_depend>
+  <exec_depend>ur_e_description</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>velocity_controllers</exec_depend>
 

--- a/src/ros/action_server.cpp
+++ b/src/ros/action_server.cpp
@@ -99,6 +99,10 @@ bool ActionServer::consume(RTState_V3_2__3& state)
 {
   return updateState(state);
 }
+bool ActionServer::consume(RTState_V3_5__5_1& state)
+{
+  return updateState(state);
+}
 
 void ActionServer::onGoal(GoalHandle gh)
 {

--- a/src/ros/rt_publisher.cpp
+++ b/src/ros/rt_publisher.cpp
@@ -134,3 +134,7 @@ bool RTPublisher::consume(RTState_V3_2__3& state)
 {
   return publish(state);
 }
+bool RTPublisher::consume(RTState_V3_5__5_1& state)
+{
+  return publish(state);
+}

--- a/src/ur/rt_state.cpp
+++ b/src/ur/rt_state.cpp
@@ -117,6 +117,19 @@ bool RTState_V3_2__3::parseWith(BinParser& bp)
   return true;
 }
 
+bool RTState_V3_5__5_1::parseWith(BinParser& bp)
+{
+  if (!bp.checkSize<RTState_V3_5__5_1>())
+    return false;
+
+  RTState_V3_2__3::parseWith(bp);
+
+  bp.parse(elbow_position);
+  bp.parse(elbow_velocity);
+
+  return true;
+}
+
 bool RTState_V1_6__7::consumeWith(URRTPacketConsumer& consumer)
 {
   return consumer.consume(*this);
@@ -130,6 +143,10 @@ bool RTState_V3_0__1::consumeWith(URRTPacketConsumer& consumer)
   return consumer.consume(*this);
 }
 bool RTState_V3_2__3::consumeWith(URRTPacketConsumer& consumer)
+{
+  return consumer.consume(*this);
+}
+bool RTState_V3_5__5_1::consumeWith(URRTPacketConsumer& consumer)
 {
   return consumer.consume(*this);
 }

--- a/tests/ur/rt_state.cpp
+++ b/tests/ur/rt_state.cpp
@@ -175,6 +175,56 @@ TEST(RTState_V3_2__3, testRandomDataParsing)
   EXPECT_TRUE(bp.empty()) << "did not consume all data";
 }
 
+TEST(RTState_V3_5__5_1, testRandomDataParsing)
+{
+  RandomDataTest rdt(1108);
+  BinParser bp = rdt.getParser(true);
+  RTState_V3_5__5_1 state;
+  EXPECT_TRUE(state.parseWith(bp)) << "parse() returned false";
+
+  ASSERT_EQ(rdt.getNext<double>(), state.time);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.q_target);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.qd_target);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.qdd_target);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.i_target);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.m_target);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.q_actual);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.qd_actual);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.i_actual);
+
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.i_control);
+  ASSERT_EQ(rdt.getNext<cartesian_coord_t>(), state.tool_vector_actual);
+  ASSERT_EQ(rdt.getNext<cartesian_coord_t>(), state.tcp_speed_actual);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.tcp_force);
+  ASSERT_EQ(rdt.getNext<cartesian_coord_t>(), state.tool_vector_target);
+  ASSERT_EQ(rdt.getNext<cartesian_coord_t>(), state.tcp_speed_target);
+
+  ASSERT_EQ(rdt.getNext<uint64_t>(), state.digital_inputs);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.motor_temperatures);
+  ASSERT_EQ(rdt.getNext<double>(), state.controller_time);
+  rdt.skip(sizeof(double));  // skip unused value
+  ASSERT_EQ(rdt.getNext<double>(), state.robot_mode);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.joint_modes);
+  ASSERT_EQ(rdt.getNext<double>(), state.safety_mode);
+  rdt.skip(sizeof(double) * 6);
+  ASSERT_EQ(rdt.getNext<double3_t>(), state.tool_accelerometer_values);
+  rdt.skip(sizeof(double) * 6);
+  ASSERT_EQ(rdt.getNext<double>(), state.speed_scaling);
+  ASSERT_EQ(rdt.getNext<double>(), state.linear_momentum_norm);
+  rdt.skip(sizeof(double) * 2);
+  ASSERT_EQ(rdt.getNext<double>(), state.v_main);
+  ASSERT_EQ(rdt.getNext<double>(), state.v_robot);
+  ASSERT_EQ(rdt.getNext<double>(), state.i_robot);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.v_actual);
+  ASSERT_EQ(rdt.getNext<uint64_t>(), state.digital_outputs);
+  ASSERT_EQ(rdt.getNext<double>(), state.program_state);
+
+  ASSERT_EQ(rdt.getNext<double3_t>(), state.elbow_position);
+  ASSERT_EQ(rdt.getNext<double3_t>(), state.elbow_velocity);
+
+  EXPECT_TRUE(bp.empty()) << "did not consume all data";
+}
+
 TEST(RTState_V1_6__7, testTooSmallBuffer)
 {
   RandomDataTest rdt(10);
@@ -204,5 +254,13 @@ TEST(RTState_V3_2__3, testTooSmallBuffer)
   RandomDataTest rdt(10);
   BinParser bp = rdt.getParser(true);
   RTState_V3_2__3 state;
+  EXPECT_FALSE(state.parseWith(bp)) << "parse() should fail when buffer not big enough";
+}
+
+TEST(RTState_V3_5__5_1, testTooSmallBuffer)
+{
+  RandomDataTest rdt(10);
+  BinParser bp = rdt.getParser(true);
+  RTState_V3_5__5_1 state;
   EXPECT_FALSE(state.parseWith(bp)) << "parse() should fail when buffer not big enough";
 }


### PR DESCRIPTION
I have updated the codes for SW>=3.5 and E-series.
I verified my updates on UR3 and UR3e.

Actually my updates was manually merging the updates from dniewinski:
  https://github.com/dniewinski/ur_modern_driver
Since many other codes were modified in dniewinski version (such as removing the copyright sections of the files), I did this manually, rather than using git merge.
My updates are minimum to merge into ros-industrial version, which would be useful to other users.

I also copied config and launch files from the dniewinski's updates.  For example, we can run:
`  $ roslaunch ur_modern_driver ur3e_bringup.launch robot_ip:=xxx.xxx.xxx.xxx`

I referred to:
https://github.com/ros-industrial/ur_modern_driver/issues/184
Especially this is important to work with E-series:
https://github.com/ros-industrial/ur_modern_driver/issues/184#issuecomment-435325436
