### PR TITLE
Notify users when no packets are received

### DIFF
--- a/include/ur_modern_driver/ros/controller.h
+++ b/include/ur_modern_driver/ros/controller.h
@@ -31,6 +31,10 @@
 #include "ur_modern_driver/ur/consumer.h"
 #include "ur_modern_driver/ur/rt_state.h"
 
+// If no packet is received for this time, a warning is issued to the user
+// CB2 and 3 cycle times are 0.008, adding some margin
+static const double PACKET_RECEIVE_WARN_TIME = 0.01;
+
 class ROSController : private hardware_interface::RobotHW, public URRTPacketConsumer, public Service
 {
 private:

--- a/include/ur_modern_driver/ros/controller.h
+++ b/include/ur_modern_driver/ros/controller.h
@@ -38,6 +38,7 @@ private:
   ros::Time lastUpdate_;
   controller_manager::ControllerManager controller_;
   bool robot_state_received_;
+  ros::Time most_recent_packet_time_;
 
   // state interfaces
   JointInterface joint_interface_;

--- a/src/ros/controller.cpp
+++ b/src/ros/controller.cpp
@@ -117,7 +117,7 @@ bool ROSController::update()
   auto diff = time - lastUpdate_;
   lastUpdate_ = time;
 
-  if ((time - most_recent_packet_time_).toSec() > 0.01)  // CB2 and 3 cycle times are 0.008, adding some margin
+  if ((time - most_recent_packet_time_).toSec() > PACKET_RECEIVE_WARN_TIME)
   {
     ROS_WARN_THROTTLE(1.0, "No new packets received from robot. Connection is probably lost");
   }


### PR DESCRIPTION
This MR aims at notifying the user once no packages are received from the robot.

This addresses #227, although it doesn't add a timeout, but introduces feedback to the user instead.