### PR TITLE
Correct frame used for Wrench messages (fix #318)

### DIFF
--- a/include/ur_modern_driver/ros/controller.h
+++ b/include/ur_modern_driver/ros/controller.h
@@ -74,7 +74,7 @@ private:
 
 public:
   ROSController(URCommander& commander, TrajectoryFollower& follower, std::vector<std::string>& joint_names,
-                double max_vel_change, std::string tcp_link);
+                double max_vel_change, std::string wrench_frame);
   virtual ~ROSController()
   {
   }

--- a/include/ur_modern_driver/ros/hardware_interface.h
+++ b/include/ur_modern_driver/ros/hardware_interface.h
@@ -61,7 +61,7 @@ class WrenchInterface : public hardware_interface::ForceTorqueSensorInterface
   std::array<double, 6> tcp_;
 
 public:
-  WrenchInterface(std::string tcp_link);
+  WrenchInterface(std::string wrench_frame);
   void update(RTShared &packet);
   typedef hardware_interface::ForceTorqueSensorInterface parent_type;
   static const std::string INTERFACE_NAME;

--- a/src/ros/controller.cpp
+++ b/src/ros/controller.cpp
@@ -19,11 +19,11 @@
 #include "ur_modern_driver/ros/controller.h"
 
 ROSController::ROSController(URCommander& commander, TrajectoryFollower& follower,
-                             std::vector<std::string>& joint_names, double max_vel_change, std::string tcp_link)
+                             std::vector<std::string>& joint_names, double max_vel_change, std::string wrench_frame)
   : controller_(this, nh_)
   , robot_state_received_(false)
   , joint_interface_(joint_names)
-  , wrench_interface_(tcp_link)
+  , wrench_interface_(wrench_frame)
   , position_interface_(follower, joint_interface_, joint_names)
   , velocity_interface_(commander, joint_interface_, joint_names, max_vel_change)
 {

--- a/src/ros/hardware_interface.cpp
+++ b/src/ros/hardware_interface.cpp
@@ -36,9 +36,11 @@ void JointInterface::update(RTShared &packet)
 }
 
 const std::string WrenchInterface::INTERFACE_NAME = "hardware_interface::ForceTorqueSensorInterface";
-WrenchInterface::WrenchInterface(std::string tcp_link)
+WrenchInterface::WrenchInterface(std::string wrench_frame)
 {
-  registerHandle(hardware_interface::ForceTorqueSensorHandle("wrench", tcp_link, tcp_.begin(), tcp_.begin() + 3));
+  // the frame_id for the Wrench is set to what is configured as the "base frame".
+  // Refer to ros-industrial/ur_modern_driver#318 for the rationale.
+  registerHandle(hardware_interface::ForceTorqueSensorHandle("wrench", wrench_frame, tcp_.begin(), tcp_.begin() + 3));
 }
 
 void WrenchInterface::update(RTShared &packet)

--- a/src/ros/rt_publisher.cpp
+++ b/src/ros/rt_publisher.cpp
@@ -37,6 +37,9 @@ bool RTPublisher::publishWrench(RTShared& packet, Time& t)
 {
   geometry_msgs::WrenchStamped wrench_msg;
   wrench_msg.header.stamp = t;
+  // Setting this to what is configured as the "base frame" through ROS parameters.
+  // Refer to ros-industrial/ur_modern_driver#318 for the rationale.
+  wrench_msg.header.frame_id = base_frame_;
   wrench_msg.wrench.force.x = packet.tcp_force[0];
   wrench_msg.wrench.force.y = packet.tcp_force[1];
   wrench_msg.wrench.force.z = packet.tcp_force[2];

--- a/src/ros_main.cpp
+++ b/src/ros_main.cpp
@@ -178,7 +178,8 @@ int main(int argc, char **argv)
     LOG_INFO("ROS control enabled");
     TrajectoryFollower *traj_follower =
         new TrajectoryFollower(*rt_commander, local_ip, args.reverse_port, factory.isVersion3());
-    controller = new ROSController(*rt_commander, *traj_follower, args.joint_names, args.max_vel_change, args.tcp_link);
+    controller =
+        new ROSController(*rt_commander, *traj_follower, args.joint_names, args.max_vel_change, args.base_frame);
     rt_vec.push_back(controller);
     services.push_back(controller);
   }


### PR DESCRIPTION
As per subject.

Followed the suggestion by @miguelprada to use the `base` frame.
