### PR TITLE
Fix to setToolVoltage checking and replacement of casting with rounding

### DIFF
--- a/include/ur_modern_driver/ros/io_service.h
+++ b/include/ur_modern_driver/ros/io_service.h
@@ -50,7 +50,7 @@ private:
         res = commander_.setAnalogOut(req.pin, req.state);
         break;
       case ur_msgs::SetIO::Request::FUN_SET_TOOL_VOLTAGE:
-        res = commander_.setToolVoltage(static_cast<uint8_t>(req.state));
+        res = commander_.setToolVoltage(std::lround(req.state));
         break;
       case ur_msgs::SetIO::Request::FUN_SET_FLAG:
         res = commander_.setFlag(req.pin, flag);

--- a/src/ur/commander.cpp
+++ b/src/ur/commander.cpp
@@ -46,7 +46,7 @@ bool URCommander::uploadProg(const std::string &s)
 
 bool URCommander::setToolVoltage(uint8_t voltage)
 {
-  if (voltage != 0 || voltage != 12 || voltage != 24)
+  if (voltage != 0 && voltage != 12 && voltage != 24)
     return false;
 
   std::ostringstream out;


### PR DESCRIPTION
Previous voltage value checking always made the service fail if trying to set the tool voltage. This was fixed and the voltage value is now rounded instead of casted to allow for minor errors on both sides of the values allowed.