### PR TITLE
Update for the SW 3.10

### DIFF
--- a/include/ur_modern_driver/event_counter.h
+++ b/include/ur_modern_driver/event_counter.h
@@ -88,6 +88,11 @@ public:
     trigger();
     return true;
   }
+  bool consume(RTState_V3_5__5_1& state)
+  {
+    trigger();
+    return true;
+  }
 
   void setupConsumer()
   {

--- a/include/ur_modern_driver/event_counter.h
+++ b/include/ur_modern_driver/event_counter.h
@@ -93,6 +93,11 @@ public:
     trigger();
     return true;
   }
+  bool consume(RTState_V3_10__5_4& state)
+  {
+    trigger();
+    return true;
+  }
 
   void setupConsumer()
   {

--- a/include/ur_modern_driver/ros/action_server.h
+++ b/include/ur_modern_driver/ros/action_server.h
@@ -91,4 +91,5 @@ public:
   virtual bool consume(RTState_V3_0__1& state);
   virtual bool consume(RTState_V3_2__3& state);
   virtual bool consume(RTState_V3_5__5_1& state);
+  virtual bool consume(RTState_V3_10__5_4& state);
 };

--- a/include/ur_modern_driver/ros/action_server.h
+++ b/include/ur_modern_driver/ros/action_server.h
@@ -90,4 +90,5 @@ public:
   virtual bool consume(RTState_V1_8& state);
   virtual bool consume(RTState_V3_0__1& state);
   virtual bool consume(RTState_V3_2__3& state);
+  virtual bool consume(RTState_V3_5__5_1& state);
 };

--- a/include/ur_modern_driver/ros/controller.h
+++ b/include/ur_modern_driver/ros/controller.h
@@ -103,6 +103,11 @@ public:
     read(state);
     return update();
   }
+  virtual bool consume(RTState_V3_5__5_1& state)
+  {
+    read(state);
+    return update();
+  }
 
   virtual void onTimeout();
 

--- a/include/ur_modern_driver/ros/controller.h
+++ b/include/ur_modern_driver/ros/controller.h
@@ -108,6 +108,11 @@ public:
     read(state);
     return update();
   }
+  virtual bool consume(RTState_V3_10__5_4& state)
+  {
+    read(state);
+    return update();
+  }
 
   virtual void onTimeout();
 

--- a/include/ur_modern_driver/ros/rt_publisher.h
+++ b/include/ur_modern_driver/ros/rt_publisher.h
@@ -88,6 +88,7 @@ public:
   virtual bool consume(RTState_V3_0__1& state);
   virtual bool consume(RTState_V3_2__3& state);
   virtual bool consume(RTState_V3_5__5_1& state);
+  virtual bool consume(RTState_V3_10__5_4& state);
 
   virtual void setupConsumer()
   {

--- a/include/ur_modern_driver/ros/rt_publisher.h
+++ b/include/ur_modern_driver/ros/rt_publisher.h
@@ -87,6 +87,7 @@ public:
   virtual bool consume(RTState_V1_8& state);
   virtual bool consume(RTState_V3_0__1& state);
   virtual bool consume(RTState_V3_2__3& state);
+  virtual bool consume(RTState_V3_5__5_1& state);
 
   virtual void setupConsumer()
   {

--- a/include/ur_modern_driver/ur/consumer.h
+++ b/include/ur_modern_driver/ur/consumer.h
@@ -37,6 +37,7 @@ public:
   virtual bool consume(RTState_V1_8& state) = 0;
   virtual bool consume(RTState_V3_0__1& state) = 0;
   virtual bool consume(RTState_V3_2__3& state) = 0;
+  virtual bool consume(RTState_V3_5__5_1& state) = 0;
 };
 
 class URStatePacketConsumer : public IConsumer<StatePacket>

--- a/include/ur_modern_driver/ur/consumer.h
+++ b/include/ur_modern_driver/ur/consumer.h
@@ -38,6 +38,7 @@ public:
   virtual bool consume(RTState_V3_0__1& state) = 0;
   virtual bool consume(RTState_V3_2__3& state) = 0;
   virtual bool consume(RTState_V3_5__5_1& state) = 0;
+  virtual bool consume(RTState_V3_10__5_4& state) = 0;
 };
 
 class URStatePacketConsumer : public IConsumer<StatePacket>

--- a/include/ur_modern_driver/ur/factory.h
+++ b/include/ur_modern_driver/ur/factory.h
@@ -110,7 +110,7 @@ public:
     {
       return std::unique_ptr<URParser<StatePacket>>(new URStateParser_V1_X);
     }
-    else
+    else if (major_version_ == 3)
     {
       if (minor_version_ < 3)
         return std::unique_ptr<URParser<StatePacket>>(new URStateParser_V3_0__1);
@@ -118,6 +118,10 @@ public:
         return std::unique_ptr<URParser<StatePacket>>(new URStateParser_V3_2);
       else
         return std::unique_ptr<URParser<StatePacket>>(new URStateParser_V3_5);
+    }
+    else
+    {
+      return std::unique_ptr<URParser<StatePacket>>(new URStateParser_V3_5);
     }
   }
 
@@ -130,12 +134,18 @@ public:
       else
         return std::unique_ptr<URParser<RTPacket>>(new URRTStateParser_V1_8);
     }
+    else if (major_version_ == 3)
+    {
+      if (minor_version_ < 2)
+        return std::unique_ptr<URParser<RTPacket>>(new URRTStateParser_V3_0__1);
+      else if (minor_version_ < 5)
+        return std::unique_ptr<URParser<RTPacket>>(new URRTStateParser_V3_2__3);
+      else
+        return std::unique_ptr<URParser<RTPacket>>(new URRTStateParser_V3_5__5_1);
+    }
     else
     {
-      if (minor_version_ < 3)
-        return std::unique_ptr<URParser<RTPacket>>(new URRTStateParser_V3_0__1);
-      else
-        return std::unique_ptr<URParser<RTPacket>>(new URRTStateParser_V3_2__3);
+      return std::unique_ptr<URParser<RTPacket>>(new URRTStateParser_V3_5__5_1);
     }
   }
 };

--- a/include/ur_modern_driver/ur/factory.h
+++ b/include/ur_modern_driver/ur/factory.h
@@ -116,12 +116,14 @@ public:
         return std::unique_ptr<URParser<StatePacket>>(new URStateParser_V3_0__1);
       else if (minor_version_ < 5)
         return std::unique_ptr<URParser<StatePacket>>(new URStateParser_V3_2);
-      else
+      else if (minor_version_ < 10)
         return std::unique_ptr<URParser<StatePacket>>(new URStateParser_V3_5);
+      else
+        return std::unique_ptr<URParser<StatePacket>>(new URStateParser_V3_10);
     }
     else
     {
-      return std::unique_ptr<URParser<StatePacket>>(new URStateParser_V3_5);
+      return std::unique_ptr<URParser<StatePacket>>(new URStateParser_V3_10);
     }
   }
 
@@ -140,12 +142,14 @@ public:
         return std::unique_ptr<URParser<RTPacket>>(new URRTStateParser_V3_0__1);
       else if (minor_version_ < 5)
         return std::unique_ptr<URParser<RTPacket>>(new URRTStateParser_V3_2__3);
-      else
+      else if (minor_version_ < 10)
         return std::unique_ptr<URParser<RTPacket>>(new URRTStateParser_V3_5__5_1);
+      else
+        return std::unique_ptr<URParser<RTPacket>>(new URRTStateParser_V3_10__5_4);
     }
     else
     {
-      return std::unique_ptr<URParser<RTPacket>>(new URRTStateParser_V3_5__5_1);
+      return std::unique_ptr<URParser<RTPacket>>(new URRTStateParser_V3_10__5_4);
     }
   }
 };

--- a/include/ur_modern_driver/ur/master_board.h
+++ b/include/ur_modern_driver/ur/master_board.h
@@ -108,3 +108,14 @@ public:
 
   static const size_t SIZE = MasterBoardData_V3_0__1::SIZE + sizeof(uint8_t) * 2;
 };
+
+class MasterBoardData_V3_10 : public MasterBoardData_V3_2
+{
+public:
+  virtual bool parseWith(BinParser& bp);
+  virtual bool consumeWith(URStatePacketConsumer& consumer);
+
+  uint8_t unknown_internal_use;
+
+  static const size_t SIZE = MasterBoardData_V3_2::SIZE + sizeof(uint8_t);
+};

--- a/include/ur_modern_driver/ur/rt_parser.h
+++ b/include/ur_modern_driver/ur/rt_parser.h
@@ -54,3 +54,4 @@ typedef URRTStateParser<RTState_V1_6__7> URRTStateParser_V1_6__7;
 typedef URRTStateParser<RTState_V1_8> URRTStateParser_V1_8;
 typedef URRTStateParser<RTState_V3_0__1> URRTStateParser_V3_0__1;
 typedef URRTStateParser<RTState_V3_2__3> URRTStateParser_V3_2__3;
+typedef URRTStateParser<RTState_V3_5__5_1> URRTStateParser_V3_5__5_1;

--- a/include/ur_modern_driver/ur/rt_parser.h
+++ b/include/ur_modern_driver/ur/rt_parser.h
@@ -55,3 +55,4 @@ typedef URRTStateParser<RTState_V1_8> URRTStateParser_V1_8;
 typedef URRTStateParser<RTState_V3_0__1> URRTStateParser_V3_0__1;
 typedef URRTStateParser<RTState_V3_2__3> URRTStateParser_V3_2__3;
 typedef URRTStateParser<RTState_V3_5__5_1> URRTStateParser_V3_5__5_1;
+typedef URRTStateParser<RTState_V3_10__5_4> URRTStateParser_V3_10__5_4;

--- a/include/ur_modern_driver/ur/rt_state.h
+++ b/include/ur_modern_driver/ur/rt_state.h
@@ -135,3 +135,17 @@ public:
 
   static_assert(RTState_V3_2__3::SIZE == 936, "RTState_V3_2__3 has mismatched size!");
 };
+
+class RTState_V3_5__5_1 : public RTState_V3_2__3
+{
+public:
+  bool parseWith(BinParser& bp);
+  virtual bool consumeWith(URRTPacketConsumer& consumer);
+
+  double3_t elbow_position;
+  double3_t elbow_velocity;
+
+  static const size_t SIZE = RTState_V3_2__3::SIZE + sizeof(double3_t) * 2;
+
+  static_assert(RTState_V3_5__5_1::SIZE == 984, "RTState_V3_5__5_1 has mismatched size!");
+};

--- a/include/ur_modern_driver/ur/rt_state.h
+++ b/include/ur_modern_driver/ur/rt_state.h
@@ -149,3 +149,16 @@ public:
 
   static_assert(RTState_V3_5__5_1::SIZE == 984, "RTState_V3_5__5_1 has mismatched size!");
 };
+
+class RTState_V3_10__5_4 : public RTState_V3_5__5_1
+{
+public:
+  bool parseWith(BinParser& bp);
+  virtual bool consumeWith(URRTPacketConsumer& consumer);
+
+  uint64_t safety_status;
+
+  static const size_t SIZE = RTState_V3_5__5_1::SIZE + sizeof(uint64_t);
+
+  static_assert(RTState_V3_10__5_4::SIZE == 992, "RTState_V3_10__5_4 has mismatched size!");
+};

--- a/include/ur_modern_driver/ur/state_parser.h
+++ b/include/ur_modern_driver/ur/state_parser.h
@@ -115,3 +115,4 @@ typedef URStateParser<RobotModeData_V1_X, MasterBoardData_V1_X> URStateParser_V1
 typedef URStateParser<RobotModeData_V3_0__1, MasterBoardData_V3_0__1> URStateParser_V3_0__1;
 typedef URStateParser<RobotModeData_V3_2, MasterBoardData_V3_2> URStateParser_V3_2;
 typedef URStateParser<RobotModeData_V3_5, MasterBoardData_V3_2> URStateParser_V3_5;
+typedef URStateParser<RobotModeData_V3_5, MasterBoardData_V3_10> URStateParser_V3_10;

--- a/src/ros/action_server.cpp
+++ b/src/ros/action_server.cpp
@@ -103,6 +103,10 @@ bool ActionServer::consume(RTState_V3_5__5_1& state)
 {
   return updateState(state);
 }
+bool ActionServer::consume(RTState_V3_10__5_4& state)
+{
+  return updateState(state);
+}
 
 void ActionServer::onGoal(GoalHandle gh)
 {

--- a/src/ros/action_server.cpp
+++ b/src/ros/action_server.cpp
@@ -99,6 +99,10 @@ bool ActionServer::consume(RTState_V3_2__3& state)
 {
   return updateState(state);
 }
+bool ActionServer::consume(RTState_V3_5__5_1& state)
+{
+  return updateState(state);
+}
 
 void ActionServer::onGoal(GoalHandle gh)
 {

--- a/src/ros/rt_publisher.cpp
+++ b/src/ros/rt_publisher.cpp
@@ -144,3 +144,7 @@ bool RTPublisher::consume(RTState_V3_5__5_1& state)
 {
   return publish(state);
 }
+bool RTPublisher::consume(RTState_V3_10__5_4& state)
+{
+  return publish(state);
+}

--- a/src/ros/rt_publisher.cpp
+++ b/src/ros/rt_publisher.cpp
@@ -140,3 +140,7 @@ bool RTPublisher::consume(RTState_V3_2__3& state)
 {
   return publish(state);
 }
+bool RTPublisher::consume(RTState_V3_5__5_1& state)
+{
+  return publish(state);
+}

--- a/src/ur/master_board.cpp
+++ b/src/ur/master_board.cpp
@@ -107,6 +107,18 @@ bool MasterBoardData_V3_2::parseWith(BinParser& bp)
   return true;
 }
 
+bool MasterBoardData_V3_10::parseWith(BinParser& bp)
+{
+  if (!bp.checkSize<MasterBoardData_V3_10>())
+    return false;
+
+  MasterBoardData_V3_2::parseWith(bp);
+
+  bp.parse(unknown_internal_use);
+
+  return true;
+}
+
 bool MasterBoardData_V1_X::consumeWith(URStatePacketConsumer& consumer)
 {
   return consumer.consume(*this);
@@ -116,6 +128,10 @@ bool MasterBoardData_V3_0__1::consumeWith(URStatePacketConsumer& consumer)
   return consumer.consume(*this);
 }
 bool MasterBoardData_V3_2::consumeWith(URStatePacketConsumer& consumer)
+{
+  return consumer.consume(*this);
+}
+bool MasterBoardData_V3_10::consumeWith(URStatePacketConsumer& consumer)
 {
   return consumer.consume(*this);
 }

--- a/src/ur/rt_state.cpp
+++ b/src/ur/rt_state.cpp
@@ -117,6 +117,19 @@ bool RTState_V3_2__3::parseWith(BinParser& bp)
   return true;
 }
 
+bool RTState_V3_5__5_1::parseWith(BinParser& bp)
+{
+  if (!bp.checkSize<RTState_V3_5__5_1>())
+    return false;
+
+  RTState_V3_2__3::parseWith(bp);
+
+  bp.parse(elbow_position);
+  bp.parse(elbow_velocity);
+
+  return true;
+}
+
 bool RTState_V1_6__7::consumeWith(URRTPacketConsumer& consumer)
 {
   return consumer.consume(*this);
@@ -130,6 +143,10 @@ bool RTState_V3_0__1::consumeWith(URRTPacketConsumer& consumer)
   return consumer.consume(*this);
 }
 bool RTState_V3_2__3::consumeWith(URRTPacketConsumer& consumer)
+{
+  return consumer.consume(*this);
+}
+bool RTState_V3_5__5_1::consumeWith(URRTPacketConsumer& consumer)
 {
   return consumer.consume(*this);
 }

--- a/src/ur/rt_state.cpp
+++ b/src/ur/rt_state.cpp
@@ -130,6 +130,18 @@ bool RTState_V3_5__5_1::parseWith(BinParser& bp)
   return true;
 }
 
+bool RTState_V3_10__5_4::parseWith(BinParser& bp)
+{
+  if (!bp.checkSize<RTState_V3_10__5_4>())
+    return false;
+
+  RTState_V3_5__5_1::parseWith(bp);
+
+  bp.parse(safety_status);
+
+  return true;
+}
+
 bool RTState_V1_6__7::consumeWith(URRTPacketConsumer& consumer)
 {
   return consumer.consume(*this);
@@ -147,6 +159,10 @@ bool RTState_V3_2__3::consumeWith(URRTPacketConsumer& consumer)
   return consumer.consume(*this);
 }
 bool RTState_V3_5__5_1::consumeWith(URRTPacketConsumer& consumer)
+{
+  return consumer.consume(*this);
+}
+bool RTState_V3_10__5_4::consumeWith(URRTPacketConsumer& consumer)
 {
   return consumer.consume(*this);
 }

--- a/tests/ur/rt_state.cpp
+++ b/tests/ur/rt_state.cpp
@@ -175,6 +175,56 @@ TEST(RTState_V3_2__3, testRandomDataParsing)
   EXPECT_TRUE(bp.empty()) << "did not consume all data";
 }
 
+TEST(RTState_V3_5__5_1, testRandomDataParsing)
+{
+  RandomDataTest rdt(1108);
+  BinParser bp = rdt.getParser(true);
+  RTState_V3_5__5_1 state;
+  EXPECT_TRUE(state.parseWith(bp)) << "parse() returned false";
+
+  ASSERT_EQ(rdt.getNext<double>(), state.time);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.q_target);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.qd_target);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.qdd_target);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.i_target);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.m_target);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.q_actual);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.qd_actual);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.i_actual);
+
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.i_control);
+  ASSERT_EQ(rdt.getNext<cartesian_coord_t>(), state.tool_vector_actual);
+  ASSERT_EQ(rdt.getNext<cartesian_coord_t>(), state.tcp_speed_actual);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.tcp_force);
+  ASSERT_EQ(rdt.getNext<cartesian_coord_t>(), state.tool_vector_target);
+  ASSERT_EQ(rdt.getNext<cartesian_coord_t>(), state.tcp_speed_target);
+
+  ASSERT_EQ(rdt.getNext<uint64_t>(), state.digital_inputs);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.motor_temperatures);
+  ASSERT_EQ(rdt.getNext<double>(), state.controller_time);
+  rdt.skip(sizeof(double));  // skip unused value
+  ASSERT_EQ(rdt.getNext<double>(), state.robot_mode);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.joint_modes);
+  ASSERT_EQ(rdt.getNext<double>(), state.safety_mode);
+  rdt.skip(sizeof(double) * 6);
+  ASSERT_EQ(rdt.getNext<double3_t>(), state.tool_accelerometer_values);
+  rdt.skip(sizeof(double) * 6);
+  ASSERT_EQ(rdt.getNext<double>(), state.speed_scaling);
+  ASSERT_EQ(rdt.getNext<double>(), state.linear_momentum_norm);
+  rdt.skip(sizeof(double) * 2);
+  ASSERT_EQ(rdt.getNext<double>(), state.v_main);
+  ASSERT_EQ(rdt.getNext<double>(), state.v_robot);
+  ASSERT_EQ(rdt.getNext<double>(), state.i_robot);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.v_actual);
+  ASSERT_EQ(rdt.getNext<uint64_t>(), state.digital_outputs);
+  ASSERT_EQ(rdt.getNext<double>(), state.program_state);
+
+  ASSERT_EQ(rdt.getNext<double3_t>(), state.elbow_position);
+  ASSERT_EQ(rdt.getNext<double3_t>(), state.elbow_velocity);
+
+  EXPECT_TRUE(bp.empty()) << "did not consume all data";
+}
+
 TEST(RTState_V1_6__7, testTooSmallBuffer)
 {
   RandomDataTest rdt(10);
@@ -204,5 +254,13 @@ TEST(RTState_V3_2__3, testTooSmallBuffer)
   RandomDataTest rdt(10);
   BinParser bp = rdt.getParser(true);
   RTState_V3_2__3 state;
+  EXPECT_FALSE(state.parseWith(bp)) << "parse() should fail when buffer not big enough";
+}
+
+TEST(RTState_V3_5__5_1, testTooSmallBuffer)
+{
+  RandomDataTest rdt(10);
+  BinParser bp = rdt.getParser(true);
+  RTState_V3_5__5_1 state;
   EXPECT_FALSE(state.parseWith(bp)) << "parse() should fail when buffer not big enough";
 }

--- a/tests/ur/rt_state.cpp
+++ b/tests/ur/rt_state.cpp
@@ -225,6 +225,58 @@ TEST(RTState_V3_5__5_1, testRandomDataParsing)
   EXPECT_TRUE(bp.empty()) << "did not consume all data";
 }
 
+TEST(RTState_V3_10__5_4, testRandomDataParsing)
+{
+  RandomDataTest rdt(1116);
+  BinParser bp = rdt.getParser(true);
+  RTState_V3_10__5_4 state;
+  EXPECT_TRUE(state.parseWith(bp)) << "parse() returned false";
+
+  ASSERT_EQ(rdt.getNext<double>(), state.time);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.q_target);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.qd_target);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.qdd_target);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.i_target);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.m_target);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.q_actual);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.qd_actual);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.i_actual);
+
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.i_control);
+  ASSERT_EQ(rdt.getNext<cartesian_coord_t>(), state.tool_vector_actual);
+  ASSERT_EQ(rdt.getNext<cartesian_coord_t>(), state.tcp_speed_actual);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.tcp_force);
+  ASSERT_EQ(rdt.getNext<cartesian_coord_t>(), state.tool_vector_target);
+  ASSERT_EQ(rdt.getNext<cartesian_coord_t>(), state.tcp_speed_target);
+
+  ASSERT_EQ(rdt.getNext<uint64_t>(), state.digital_inputs);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.motor_temperatures);
+  ASSERT_EQ(rdt.getNext<double>(), state.controller_time);
+  rdt.skip(sizeof(double));  // skip unused value
+  ASSERT_EQ(rdt.getNext<double>(), state.robot_mode);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.joint_modes);
+  ASSERT_EQ(rdt.getNext<double>(), state.safety_mode);
+  rdt.skip(sizeof(double) * 6);
+  ASSERT_EQ(rdt.getNext<double3_t>(), state.tool_accelerometer_values);
+  rdt.skip(sizeof(double) * 6);
+  ASSERT_EQ(rdt.getNext<double>(), state.speed_scaling);
+  ASSERT_EQ(rdt.getNext<double>(), state.linear_momentum_norm);
+  rdt.skip(sizeof(double) * 2);
+  ASSERT_EQ(rdt.getNext<double>(), state.v_main);
+  ASSERT_EQ(rdt.getNext<double>(), state.v_robot);
+  ASSERT_EQ(rdt.getNext<double>(), state.i_robot);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.v_actual);
+  ASSERT_EQ(rdt.getNext<uint64_t>(), state.digital_outputs);
+  ASSERT_EQ(rdt.getNext<double>(), state.program_state);
+
+  ASSERT_EQ(rdt.getNext<double3_t>(), state.elbow_position);
+  ASSERT_EQ(rdt.getNext<double3_t>(), state.elbow_velocity);
+
+  ASSERT_EQ(rdt.getNext<uint64_t>(), state.safety_status);
+
+  EXPECT_TRUE(bp.empty()) << "did not consume all data";
+}
+
 TEST(RTState_V1_6__7, testTooSmallBuffer)
 {
   RandomDataTest rdt(10);
@@ -262,5 +314,13 @@ TEST(RTState_V3_5__5_1, testTooSmallBuffer)
   RandomDataTest rdt(10);
   BinParser bp = rdt.getParser(true);
   RTState_V3_5__5_1 state;
+  EXPECT_FALSE(state.parseWith(bp)) << "parse() should fail when buffer not big enough";
+}
+
+TEST(RTState_V3_10__5_4, testTooSmallBuffer)
+{
+  RandomDataTest rdt(10);
+  BinParser bp = rdt.getParser(true);
+  RTState_V3_10__5_4 state;
   EXPECT_FALSE(state.parseWith(bp)) << "parse() should fail when buffer not big enough";
 }


### PR DESCRIPTION
The latest version of the UR firmware (3.10) adds an extra byte (Safety Status).  This request fixes the problem following the procedure in #310, which solves a similar issue for previous firmware versions. I used the reference in this link: https://www.universal-robots.com/how-tos-and-faqs/how-to/ur-how-tos/remote-control-via-tcpip-16496/

Should fix issue #316.

This was tested with the real UR5 (not UR5e) running firmware 3.10.

