### PR TITLE
UR e-series 5.4 and 3.10 compatibility update

### DIFF
--- a/.travis.rosinstall.kinetic
+++ b/.travis.rosinstall.kinetic
@@ -1,0 +1,4 @@
+- git:
+    local-name: universal_robot
+    uri: 'https://github.com/ros-industrial/universal_robot.git'
+    version: kinetic-devel

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,17 @@ env:
     - ROS_DISTRO="indigo"  ROS_REPO=ros-shadow-fixed NOT_TEST_INSTALL=true
     - ROS_DISTRO="kinetic" ROS_REPO=ros              NOT_TEST_INSTALL=true
     - ROS_DISTRO="kinetic" ROS_REPO=ros-shadow-fixed NOT_TEST_INSTALL=true
+    - ROS_DISTRO="kinetic" ROS_REPO=ros              NOT_TEST_INSTALL=true UPSTREAM_WORKSPACE=file
+    - ROS_DISTRO="kinetic" ROS_REPO=ros-shadow-fixed NOT_TEST_INSTALL=true UPSTREAM_WORKSPACE=file
     - ROS_DISTRO="kinetic" CLANG_FORMAT_CHECK=file
+matrix:
+  allow_failures:
+    - env: ROS_DISTRO="indigo"  ROS_REPO=ros              NOT_TEST_INSTALL=true
+    - env: ROS_DISTRO="indigo"  ROS_REPO=ros-shadow-fixed NOT_TEST_INSTALL=true
+    - env: ROS_DISTRO="kinetic" ROS_REPO=ros              NOT_TEST_INSTALL=true
+    - env: ROS_DISTRO="kinetic" ROS_REPO=ros-shadow-fixed NOT_TEST_INSTALL=true
 
 install:
   - git clone --depth=1 https://github.com/ros-industrial/industrial_ci.git .ci_config
-script: 
+script:
   - .ci_config/travis.sh

--- a/README.md
+++ b/README.md
@@ -152,6 +152,12 @@ controller_list:
       - wrist_3_joint
 ```
 
+### Troubleshooting
+
+If robot is overshooting the goal state, try setting ```use_lowbandwidth_trajectory_follower``` = TRUE in launch file.
+
+If robot is planning excessive joint movements, try using ```urXX_bringup_joint_limited.launch``` or ```urXXe_bringup_joint_limited.launch``` instead when launching driver.
+
 ## Using the tool0_controller frame
 
 Each robot from UR is calibrated individually, so there is a small error (in the order of millimeters) between the end-effector reported by the URDF models in https://github.com/ros-industrial/universal_robot/tree/indigo-devel/ur_description and
@@ -180,6 +186,7 @@ Should be compatible with all robots and control boxes with the newest firmware.
 
 ### Tested with:
 
+* Real UR10e running 5.4.2.76197
 * Real UR10 with CB2 running 1.8.14035
 * Real UR5 with CB2 running 1.8.14035
 * Simulated UR3 running 3.1.18024

--- a/README.md
+++ b/README.md
@@ -91,6 +91,11 @@ If you would like to run this package to connect to the hardware, you only need 
 ```
 roslaunch ur_modern_driver urXX_bringup.launch robot_ip:=ROBOT_IP_ADDRESS
 ```
+For e-series, enable URCaps Remote Control in System Settings. Once enabled, turn on Remote Control in the Profile menu. 
+Run the launch file: 
+```
+roslaunch ur_modern_driver urXXe_bringup.launch robot_ip:=ROBOT_IP_ADDRESS
+```
 
 Where ROBOT_IP_ADDRESS is your UR arm's IP and XX is '5' or '10' depending on your robot. The above launch file makes calls to both roscore and the launch file to the urXX_description so that ROS's parameter server has information on your robot arm. If you do not have your ```ur_description``` installed please do so via:
 ```
@@ -98,10 +103,17 @@ sudo apt install ros-<distro>-ur-description
 ```
 
 Where <distro> is the ROS distribution your machine is running on. You may want to run MoveIt to plan and execute actions on the arm. You can do so by simply entering the following commands after launching ```ur_modern_driver```:
+ 
 ```
 roslaunch urXX_moveit_config ur5_moveit_planning_execution.launch
 roslaunch urXX_moveit_config moveit_rviz.launch config:=true
 ```
+ 
+ For e-series: 
+ ```
+ roslaunch urXX_e_moveit_config urXX_e_moveit_planning_execution.launch
+ roslaunch urXX_e_moveit_config moveit_rviz.launch config:=true
+ ```
 ---
 If you would like to use the ros\_control-based approach, use the launch files urXX\_ros\_control.launch, where XX is '5' or '10' depending on your robot.
 

--- a/include/ur_modern_driver/event_counter.h
+++ b/include/ur_modern_driver/event_counter.h
@@ -70,6 +70,11 @@ public:
     trigger();
     return true;
   }
+  bool consume(RTState_V3_5__5_1& state)
+  {
+    trigger();
+    return true;
+  }
 
   void setupConsumer()
   {

--- a/include/ur_modern_driver/event_counter.h
+++ b/include/ur_modern_driver/event_counter.h
@@ -76,6 +76,12 @@ public:
     return true;
   }
 
+  bool consume(RTState_V3_10__5_4& state)
+  {
+    trigger();
+    return true;
+  }
+
   void setupConsumer()
   {
     last_ = Clock::now();

--- a/include/ur_modern_driver/ros/action_server.h
+++ b/include/ur_modern_driver/ros/action_server.h
@@ -70,4 +70,5 @@ public:
   virtual bool consume(RTState_V1_8& state);
   virtual bool consume(RTState_V3_0__1& state);
   virtual bool consume(RTState_V3_2__3& state);
+  virtual bool consume(RTState_V3_5__5_1& state);
 };

--- a/include/ur_modern_driver/ros/action_server.h
+++ b/include/ur_modern_driver/ros/action_server.h
@@ -71,4 +71,5 @@ public:
   virtual bool consume(RTState_V3_0__1& state);
   virtual bool consume(RTState_V3_2__3& state);
   virtual bool consume(RTState_V3_5__5_1& state);
+  virtual bool consume(RTState_V3_10__5_4& state);
 };

--- a/include/ur_modern_driver/ros/controller.h
+++ b/include/ur_modern_driver/ros/controller.h
@@ -85,6 +85,11 @@ public:
     read(state);
     return update();
   }
+  virtual bool consume(RTState_V3_5__5_1& state)
+  {
+    read(state);
+    return update();
+  }
 
   virtual void onTimeout();
 

--- a/include/ur_modern_driver/ros/controller.h
+++ b/include/ur_modern_driver/ros/controller.h
@@ -91,6 +91,12 @@ public:
     return update();
   }
 
+  virtual bool consume(RTState_V3_10__5_4& state)
+  {
+    read(state);
+    return update();
+  }
+
   virtual void onTimeout();
 
   virtual void onRobotStateChange(RobotState state);

--- a/include/ur_modern_driver/ros/rt_publisher.h
+++ b/include/ur_modern_driver/ros/rt_publisher.h
@@ -61,6 +61,7 @@ public:
   virtual bool consume(RTState_V1_8& state);
   virtual bool consume(RTState_V3_0__1& state);
   virtual bool consume(RTState_V3_2__3& state);
+  virtual bool consume(RTState_V3_5__5_1& state);
 
   virtual void setupConsumer()
   {

--- a/include/ur_modern_driver/ros/rt_publisher.h
+++ b/include/ur_modern_driver/ros/rt_publisher.h
@@ -62,6 +62,7 @@ public:
   virtual bool consume(RTState_V3_0__1& state);
   virtual bool consume(RTState_V3_2__3& state);
   virtual bool consume(RTState_V3_5__5_1& state);
+  virtual bool consume(RTState_V3_10__5_4& state);
 
   virtual void setupConsumer()
   {

--- a/include/ur_modern_driver/ur/consumer.h
+++ b/include/ur_modern_driver/ur/consumer.h
@@ -19,6 +19,7 @@ public:
   virtual bool consume(RTState_V1_8& state) = 0;
   virtual bool consume(RTState_V3_0__1& state) = 0;
   virtual bool consume(RTState_V3_2__3& state) = 0;
+  virtual bool consume(RTState_V3_5__5_1& state) = 0;
 };
 
 class URStatePacketConsumer : public IConsumer<StatePacket>

--- a/include/ur_modern_driver/ur/consumer.h
+++ b/include/ur_modern_driver/ur/consumer.h
@@ -20,6 +20,7 @@ public:
   virtual bool consume(RTState_V3_0__1& state) = 0;
   virtual bool consume(RTState_V3_2__3& state) = 0;
   virtual bool consume(RTState_V3_5__5_1& state) = 0;
+  virtual bool consume(RTState_V3_10__5_4& state) = 0;
 };
 
 class URStatePacketConsumer : public IConsumer<StatePacket>

--- a/include/ur_modern_driver/ur/factory.h
+++ b/include/ur_modern_driver/ur/factory.h
@@ -73,7 +73,7 @@ public:
 
   bool isVersion3()
   {
-    return major_version_ == 3;
+    return major_version_ >= 3;
   }
 
   std::unique_ptr<URCommander> getCommander(URStream& stream)

--- a/include/ur_modern_driver/ur/factory.h
+++ b/include/ur_modern_driver/ur/factory.h
@@ -112,12 +112,18 @@ public:
       else
         return std::unique_ptr<URParser<RTPacket>>(new URRTStateParser_V1_8);
     }
+    else if(major_version_ == 3)
+    {
+      if (minor_version_ < 2)
+        return std::unique_ptr<URParser<RTPacket>>(new URRTStateParser_V3_0__1);
+      else if (minor_version_ < 5)
+        return std::unique_ptr<URParser<RTPacket>>(new URRTStateParser_V3_2__3);
+      else
+        return std::unique_ptr<URParser<RTPacket>>(new URRTStateParser_V3_5__5_1);
+    }
     else
     {
-      if (minor_version_ < 3)
-        return std::unique_ptr<URParser<RTPacket>>(new URRTStateParser_V3_0__1);
-      else
-        return std::unique_ptr<URParser<RTPacket>>(new URRTStateParser_V3_2__3);
+      return std::unique_ptr<URParser<RTPacket>>(new URRTStateParser_V3_5__5_1);
     }
   }
 };

--- a/include/ur_modern_driver/ur/factory.h
+++ b/include/ur_modern_driver/ur/factory.h
@@ -108,7 +108,7 @@ public:
       else if (minor_version_ <10)
         return std::unique_ptr<URParser<StatePacket>>(new URStateParser_V3_5);
       else if (minor_version_ <11)
-        return std::unique_ptr<URParser<StatePacket>>(new URStateParser_V3_10);
+        return std::unique_ptr<URParser<StatePacket>>(new URStateParser_V3_10__5_4);
       else
       {
         LOG_FATAL("UR software version %u.%u not yet supported", major_version_, minor_version_);
@@ -120,7 +120,7 @@ public:
       if (minor_version_ < 4)
         return std::unique_ptr<URParser<StatePacket>>(new URStateParser_V3_5);
       else if (minor_version_ < 5)
-        return std::unique_ptr<URParser<StatePacket>>(new URStateParser_V3_10);
+        return std::unique_ptr<URParser<StatePacket>>(new URStateParser_V3_10__5_4);
     }
     else
     {
@@ -161,7 +161,6 @@ public:
       else if (minor_version_ < 5)
       {
         return std::unique_ptr<URParser<RTPacket>>(new URRTStateParser_V3_10__5_4);
-        ROS_INFO("URRTStateParser_V3_10__5_4 used");
       }
       else
       {

--- a/include/ur_modern_driver/ur/factory.h
+++ b/include/ur_modern_driver/ur/factory.h
@@ -73,17 +73,24 @@ public:
 
   bool isVersion3()
   {
-    return major_version_ == 3;
+      return major_version_ ==3;
   }
 
   std::unique_ptr<URCommander> getCommander(URStream& stream)
   {
     if (major_version_ == 1)
       return std::unique_ptr<URCommander>(new URCommander_V1_X(stream));
-    else if (minor_version_ < 3)
-      return std::unique_ptr<URCommander>(new URCommander_V3_1__2(stream));
-    else
+    else if (major_version_ == 3)
+    {
+      if (minor_version_ < 3)
+        return std::unique_ptr<URCommander>(new URCommander_V3_1__2(stream));
+      else
+        return std::unique_ptr<URCommander>(new URCommander_V3_3(stream));
+    }
+    else if (major_version_ == 5)
+    {
       return std::unique_ptr<URCommander>(new URCommander_V3_3(stream));
+    }
   }
 
   std::unique_ptr<URParser<StatePacket>> getStateParser()
@@ -98,12 +105,27 @@ public:
         return std::unique_ptr<URParser<StatePacket>>(new URStateParser_V3_0__1);
       else if (minor_version_ < 5)
         return std::unique_ptr<URParser<StatePacket>>(new URStateParser_V3_2);
-      else
+      else if (minor_version_ <10)
         return std::unique_ptr<URParser<StatePacket>>(new URStateParser_V3_5);
+      else if (minor_version_ <11)
+        return std::unique_ptr<URParser<StatePacket>>(new URStateParser_V3_10);
+      else
+      {
+        LOG_FATAL("UR software version %u.%u not yet supported", major_version_, minor_version_);
+        std::exit(EXIT_FAILURE);
+      }
+    }
+    else if (major_version_ == 5)
+    {
+      if (minor_version_ < 4)
+        return std::unique_ptr<URParser<StatePacket>>(new URStateParser_V3_5);
+      else if (minor_version_ < 5)
+        return std::unique_ptr<URParser<StatePacket>>(new URStateParser_V3_10);
     }
     else
     {
-      return std::unique_ptr<URParser<StatePacket>>(new URStateParser_V3_5);
+      LOG_FATAL("UR software version %u.%u not yet supported", major_version_, minor_version_);
+      std::exit(EXIT_FAILURE);
     }
   }
 
@@ -122,12 +144,35 @@ public:
         return std::unique_ptr<URParser<RTPacket>>(new URRTStateParser_V3_0__1);
       else if (minor_version_ < 5)
         return std::unique_ptr<URParser<RTPacket>>(new URRTStateParser_V3_2__3);
-      else
+      else if (minor_version_ <10)
         return std::unique_ptr<URParser<RTPacket>>(new URRTStateParser_V3_5__5_1);
+      else if (minor_version_ <11)
+        return std::unique_ptr<URParser<RTPacket>>(new URRTStateParser_V3_10__5_4);
+      else
+      {
+        LOG_FATAL("UR software version %u.%u not yet supported", major_version_, minor_version_);
+        std::exit(EXIT_FAILURE);
+      }
+    }
+    else if (major_version_ == 5)
+    {
+      if (minor_version_ < 4)
+        return std::unique_ptr<URParser<RTPacket>>(new URRTStateParser_V3_5__5_1);
+      else if (minor_version_ < 5)
+      {
+        return std::unique_ptr<URParser<RTPacket>>(new URRTStateParser_V3_10__5_4);
+        ROS_INFO("URRTStateParser_V3_10__5_4 used");
+      }
+      else
+      {
+        LOG_FATAL("UR software version %u.%u not yet supported", major_version_, minor_version_);
+        std::exit(EXIT_FAILURE);
+      }
     }
     else
     {
-      return std::unique_ptr<URParser<RTPacket>>(new URRTStateParser_V3_5__5_1);
+      LOG_FATAL("UR software version %u.%u not yet supported", major_version_, minor_version_);
+      std::exit(EXIT_FAILURE);
     }
-  }
+   }
 };

--- a/include/ur_modern_driver/ur/factory.h
+++ b/include/ur_modern_driver/ur/factory.h
@@ -73,7 +73,7 @@ public:
 
   bool isVersion3()
   {
-      return major_version_ ==3;
+      return major_version_ == 3;
   }
 
   std::unique_ptr<URCommander> getCommander(URStream& stream)
@@ -105,9 +105,9 @@ public:
         return std::unique_ptr<URParser<StatePacket>>(new URStateParser_V3_0__1);
       else if (minor_version_ < 5)
         return std::unique_ptr<URParser<StatePacket>>(new URStateParser_V3_2);
-      else if (minor_version_ <10)
+      else if (minor_version_ < 10)
         return std::unique_ptr<URParser<StatePacket>>(new URStateParser_V3_5);
-      else if (minor_version_ <11)
+      else if (minor_version_ >= 10)
         return std::unique_ptr<URParser<StatePacket>>(new URStateParser_V3_10__5_4);
       else
       {
@@ -119,7 +119,7 @@ public:
     {
       if (minor_version_ < 4)
         return std::unique_ptr<URParser<StatePacket>>(new URStateParser_V3_5);
-      else if (minor_version_ < 5)
+      else if (minor_version_ >= 4)
         return std::unique_ptr<URParser<StatePacket>>(new URStateParser_V3_10__5_4);
     }
     else
@@ -146,7 +146,7 @@ public:
         return std::unique_ptr<URParser<RTPacket>>(new URRTStateParser_V3_2__3);
       else if (minor_version_ <10)
         return std::unique_ptr<URParser<RTPacket>>(new URRTStateParser_V3_5__5_1);
-      else if (minor_version_ <11)
+      else if (minor_version_ >= 10)
         return std::unique_ptr<URParser<RTPacket>>(new URRTStateParser_V3_10__5_4);
       else
       {
@@ -158,7 +158,7 @@ public:
     {
       if (minor_version_ < 4)
         return std::unique_ptr<URParser<RTPacket>>(new URRTStateParser_V3_5__5_1);
-      else if (minor_version_ < 5)
+      else if (minor_version_ >= 4)
       {
         return std::unique_ptr<URParser<RTPacket>>(new URRTStateParser_V3_10__5_4);
       }

--- a/include/ur_modern_driver/ur/factory.h
+++ b/include/ur_modern_driver/ur/factory.h
@@ -73,7 +73,7 @@ public:
 
   bool isVersion3()
   {
-      return major_version_ == 3;
+    return major_version_ == 3;
   }
 
   std::unique_ptr<URCommander> getCommander(URStream& stream)
@@ -144,7 +144,7 @@ public:
         return std::unique_ptr<URParser<RTPacket>>(new URRTStateParser_V3_0__1);
       else if (minor_version_ < 5)
         return std::unique_ptr<URParser<RTPacket>>(new URRTStateParser_V3_2__3);
-      else if (minor_version_ <10)
+      else if (minor_version_ < 10)
         return std::unique_ptr<URParser<RTPacket>>(new URRTStateParser_V3_5__5_1);
       else if (minor_version_ >= 10)
         return std::unique_ptr<URParser<RTPacket>>(new URRTStateParser_V3_10__5_4);
@@ -173,5 +173,5 @@ public:
       LOG_FATAL("UR software version %u.%u not yet supported", major_version_, minor_version_);
       std::exit(EXIT_FAILURE);
     }
-   }
+  }
 };

--- a/include/ur_modern_driver/ur/factory.h
+++ b/include/ur_modern_driver/ur/factory.h
@@ -92,7 +92,7 @@ public:
     {
       return std::unique_ptr<URParser<StatePacket>>(new URStateParser_V1_X);
     }
-    else if(major_version_ == 3)
+    else if (major_version_ == 3)
     {
       if (minor_version_ < 3)
         return std::unique_ptr<URParser<StatePacket>>(new URStateParser_V3_0__1);
@@ -116,7 +116,7 @@ public:
       else
         return std::unique_ptr<URParser<RTPacket>>(new URRTStateParser_V1_8);
     }
-    else if(major_version_ == 3)
+    else if (major_version_ == 3)
     {
       if (minor_version_ < 2)
         return std::unique_ptr<URParser<RTPacket>>(new URRTStateParser_V3_0__1);

--- a/include/ur_modern_driver/ur/factory.h
+++ b/include/ur_modern_driver/ur/factory.h
@@ -92,7 +92,7 @@ public:
     {
       return std::unique_ptr<URParser<StatePacket>>(new URStateParser_V1_X);
     }
-    else
+    else if(major_version_ == 3)
     {
       if (minor_version_ < 3)
         return std::unique_ptr<URParser<StatePacket>>(new URStateParser_V3_0__1);
@@ -100,6 +100,10 @@ public:
         return std::unique_ptr<URParser<StatePacket>>(new URStateParser_V3_2);
       else
         return std::unique_ptr<URParser<StatePacket>>(new URStateParser_V3_5);
+    }
+    else
+    {
+      return std::unique_ptr<URParser<StatePacket>>(new URStateParser_V3_5);
     }
   }
 

--- a/include/ur_modern_driver/ur/master_board.h
+++ b/include/ur_modern_driver/ur/master_board.h
@@ -90,3 +90,13 @@ public:
 
   static const size_t SIZE = MasterBoardData_V3_0__1::SIZE + sizeof(uint8_t) * 2;
 };
+
+class MasterBoardData_V3_10 : public MasterBoardData_V3_2
+{
+public:
+  virtual bool parseWith(BinParser& bp);
+  virtual bool consumeWith(URStatePacketConsumer& consumer);
+
+  int8_t unknown_UR_internal;
+  static const size_t SIZE = MasterBoardData_V3_2::SIZE + sizeof(char);
+};

--- a/include/ur_modern_driver/ur/master_board.h
+++ b/include/ur_modern_driver/ur/master_board.h
@@ -91,7 +91,7 @@ public:
   static const size_t SIZE = MasterBoardData_V3_0__1::SIZE + sizeof(uint8_t) * 2;
 };
 
-class MasterBoardData_V3_10 : public MasterBoardData_V3_2
+class MasterBoardData_V3_10__5_4 : public MasterBoardData_V3_2
 {
 public:
   virtual bool parseWith(BinParser& bp);

--- a/include/ur_modern_driver/ur/robot_mode.h
+++ b/include/ur_modern_driver/ur/robot_mode.h
@@ -49,7 +49,7 @@ public:
 
   static const size_t SIZE = SharedRobotModeData::SIZE + sizeof(uint8_t) + sizeof(robot_mode_V1_X) + sizeof(double);
 
-  static_assert(RobotModeData_V1_X::SIZE == 24, "RobotModeData_V1_X has missmatched size");
+  static_assert(RobotModeData_V1_X::SIZE == 24, "RobotModeData_V1_X has mismatched size");
 };
 
 enum class robot_mode_V3_X : uint8_t
@@ -88,7 +88,7 @@ public:
   static const size_t SIZE = SharedRobotModeData::SIZE + sizeof(uint8_t) + sizeof(robot_mode_V3_X) +
                              sizeof(robot_control_mode_V3_X) + sizeof(double) + sizeof(double);
 
-  static_assert(RobotModeData_V3_0__1::SIZE == 33, "RobotModeData_V3_0__1 has missmatched size");
+  static_assert(RobotModeData_V3_0__1::SIZE == 33, "RobotModeData_V3_0__1 has mismatched size");
 };
 
 class RobotModeData_V3_2 : public RobotModeData_V3_0__1
@@ -101,7 +101,7 @@ public:
 
   static const size_t SIZE = RobotModeData_V3_0__1::SIZE + sizeof(double);
 
-  static_assert(RobotModeData_V3_2::SIZE == 41, "RobotModeData_V3_2 has missmatched size");
+  static_assert(RobotModeData_V3_2::SIZE == 41, "RobotModeData_V3_2 has mismatched size");
 };
 
 class RobotModeData_V3_5 : public RobotModeData_V3_2
@@ -114,5 +114,6 @@ public:
 
   static const size_t SIZE = RobotModeData_V3_2::SIZE + sizeof(unsigned char);
 
-  static_assert(RobotModeData_V3_5::SIZE == 42, "RobotModeData_V3_5 has missmatched size");
+  static_assert(RobotModeData_V3_5::SIZE == 42, "RobotModeData_V3_5 has mismatched size");
 };
+

--- a/include/ur_modern_driver/ur/robot_mode.h
+++ b/include/ur_modern_driver/ur/robot_mode.h
@@ -116,4 +116,3 @@ public:
 
   static_assert(RobotModeData_V3_5::SIZE == 42, "RobotModeData_V3_5 has mismatched size");
 };
-

--- a/include/ur_modern_driver/ur/rt_parser.h
+++ b/include/ur_modern_driver/ur/rt_parser.h
@@ -36,3 +36,4 @@ typedef URRTStateParser<RTState_V1_6__7> URRTStateParser_V1_6__7;
 typedef URRTStateParser<RTState_V1_8> URRTStateParser_V1_8;
 typedef URRTStateParser<RTState_V3_0__1> URRTStateParser_V3_0__1;
 typedef URRTStateParser<RTState_V3_2__3> URRTStateParser_V3_2__3;
+typedef URRTStateParser<RTState_V3_5__5_1> URRTStateParser_V3_5__5_1;

--- a/include/ur_modern_driver/ur/rt_parser.h
+++ b/include/ur_modern_driver/ur/rt_parser.h
@@ -37,3 +37,4 @@ typedef URRTStateParser<RTState_V1_8> URRTStateParser_V1_8;
 typedef URRTStateParser<RTState_V3_0__1> URRTStateParser_V3_0__1;
 typedef URRTStateParser<RTState_V3_2__3> URRTStateParser_V3_2__3;
 typedef URRTStateParser<RTState_V3_5__5_1> URRTStateParser_V3_5__5_1;
+typedef URRTStateParser<RTState_V3_10__5_4> URRTStateParser_V3_10__5_4;

--- a/include/ur_modern_driver/ur/rt_state.h
+++ b/include/ur_modern_driver/ur/rt_state.h
@@ -117,3 +117,17 @@ public:
 
   static_assert(RTState_V3_2__3::SIZE == 936, "RTState_V3_2__3 has mismatched size!");
 };
+
+class RTState_V3_5__5_1 : public RTState_V3_2__3
+{
+public:
+  bool parseWith(BinParser& bp);
+  virtual bool consumeWith(URRTPacketConsumer& consumer);
+
+  double3_t elbow_position;
+  double3_t elbow_velocity;
+
+  static const size_t SIZE = RTState_V3_2__3::SIZE + sizeof(double3_t) * 2;
+
+  static_assert(RTState_V3_5__5_1::SIZE == 984, "RTState_V3_5__5_1 has mismatched size!");
+};

--- a/include/ur_modern_driver/ur/rt_state.h
+++ b/include/ur_modern_driver/ur/rt_state.h
@@ -131,3 +131,16 @@ public:
 
   static_assert(RTState_V3_5__5_1::SIZE == 984, "RTState_V3_5__5_1 has mismatched size!");
 };
+
+class RTState_V3_10__5_4 : public RTState_V3_5__5_1
+{
+public:
+  bool parseWith(BinParser& bp);
+  virtual bool consumeWith(URRTPacketConsumer& consumer);
+
+  double safety_status;
+
+  static const size_t SIZE = RTState_V3_5__5_1::SIZE + sizeof(double);
+
+  static_assert(RTState_V3_10__5_4::SIZE == 992, "RTState_V3_10__5_4 has mismatched size!");
+};

--- a/include/ur_modern_driver/ur/state_parser.h
+++ b/include/ur_modern_driver/ur/state_parser.h
@@ -32,10 +32,11 @@ public:
     message_type type;
     bp.parse(packet_size);
     bp.parse(type);
-
+    LOG_WARN("Received message type: %u", static_cast<uint8_t>(type));
     if (type != message_type::ROBOT_STATE)
     {
       // quietly ignore the intial version message
+
       if (type != message_type::ROBOT_MESSAGE)
       {
         LOG_WARN("Invalid state message type recieved: %u", static_cast<uint8_t>(type));
@@ -53,6 +54,8 @@ public:
         return false;
       }
       uint32_t sub_size = bp.peek<uint32_t>();
+      LOG_INFO("Received package of size %" PRIu32, sub_size);
+
       if (!bp.checkSize(static_cast<size_t>(sub_size)))
       {
         LOG_WARN("Invalid sub-package size of %" PRIu32 " received!", sub_size);
@@ -97,3 +100,4 @@ typedef URStateParser<RobotModeData_V1_X, MasterBoardData_V1_X> URStateParser_V1
 typedef URStateParser<RobotModeData_V3_0__1, MasterBoardData_V3_0__1> URStateParser_V3_0__1;
 typedef URStateParser<RobotModeData_V3_2, MasterBoardData_V3_2> URStateParser_V3_2;
 typedef URStateParser<RobotModeData_V3_5, MasterBoardData_V3_2> URStateParser_V3_5;
+typedef URStateParser<RobotModeData_V3_5, MasterBoardData_V3_10> URStateParser_V3_10;

--- a/include/ur_modern_driver/ur/state_parser.h
+++ b/include/ur_modern_driver/ur/state_parser.h
@@ -100,4 +100,4 @@ typedef URStateParser<RobotModeData_V1_X, MasterBoardData_V1_X> URStateParser_V1
 typedef URStateParser<RobotModeData_V3_0__1, MasterBoardData_V3_0__1> URStateParser_V3_0__1;
 typedef URStateParser<RobotModeData_V3_2, MasterBoardData_V3_2> URStateParser_V3_2;
 typedef URStateParser<RobotModeData_V3_5, MasterBoardData_V3_2> URStateParser_V3_5;
-typedef URStateParser<RobotModeData_V3_5, MasterBoardData_V3_10> URStateParser_V3_10;
+typedef URStateParser<RobotModeData_V3_5, MasterBoardData_V3_10__5_4> URStateParser_V3_10__5_4;

--- a/launch/ur10e_bringup.launch
+++ b/launch/ur10e_bringup.launch
@@ -1,0 +1,52 @@
+<?xml version="1.0"?>
+<!--
+  Universal robot ur10e launch.  Loads ur10e robot description (see ur_common.launch
+  for more info)
+
+  Usage:
+    ur10e_bringup.launch robot_ip:=<value>
+-->
+<launch>
+
+  <!-- robot_ip: IP-address of the robot's socket-messaging server -->
+  <arg name="robot_ip"/>
+  <arg name="limited" default="false"/>
+  <arg name="min_payload"  default="0.0"/>
+  <arg name="max_payload"  default="10.0"/>
+  <arg name="prefix" default="" />
+  <arg name="use_lowbandwidth_trajectory_follower" default="false"/>
+  <arg name="time_interval" default="0.008"/>
+  <arg name="servoj_time" default="0.008" />
+  <arg name="servoj_time_waiting" default="0.001" />
+  <arg name="max_waiting_time" default="2.0" />
+  <arg name="servoj_gain" default="100." />
+  <arg name="servoj_lookahead_time" default="1." />
+  <arg name="max_joint_difference" default="0.01" />
+  <arg name="base_frame" default="$(arg prefix)base" />
+  <arg name="tool_frame" default="$(arg prefix)tool0_controller" />
+  <arg name="shutdown_on_disconnect" default="true" />
+  <!-- robot model -->
+  <include file="$(find ur_e_description)/launch/ur10e_upload.launch">
+    <arg name="limited" value="$(arg limited)"/>
+  </include>
+
+  <!-- ur common -->
+  <include file="$(find ur_modern_driver)/launch/ur_common.launch">
+    <arg name="robot_ip" value="$(arg robot_ip)"/>
+    <arg name="min_payload"  value="$(arg min_payload)"/>
+    <arg name="max_payload"  value="$(arg max_payload)"/>
+    <arg name="prefix" default="" />
+    <arg name="use_lowbandwidth_trajectory_follower" value="$(arg use_lowbandwidth_trajectory_follower)"/>
+    <arg name="time_interval" value="$(arg time_interval)"/>
+    <arg name="servoj_time" value="$(arg servoj_time)" />
+    <arg name="servoj_time_waiting" default="$(arg servoj_time_waiting)" />
+    <arg name="max_waiting_time" value="$(arg max_waiting_time)" />
+    <arg name="servoj_gain" value="$(arg servoj_gain)" />
+    <arg name="servoj_lookahead_time" value="$(arg servoj_lookahead_time)" />
+    <arg name="max_joint_difference" value="$(arg max_joint_difference)" />
+    <arg name="base_frame" value="$(arg base_frame)" />
+    <arg name="tool_frame" value="$(arg tool_frame)" />
+    <arg name="shutdown_on_disconnect" value="$(arg shutdown_on_disconnect)"/>
+  </include>
+
+</launch>

--- a/launch/ur10e_bringup.launch
+++ b/launch/ur10e_bringup.launch
@@ -10,6 +10,7 @@
 
   <!-- robot_ip: IP-address of the robot's socket-messaging server -->
   <arg name="robot_ip"/>
+  <arg name="reverse_ip" default="" doc="IP of the computer running the driver" />
   <arg name="reverse_port" default="50001"/>
   <arg name="limited" default="false"/>
   <arg name="min_payload"  default="0.0"/>
@@ -34,6 +35,7 @@
   <!-- ur common -->
   <include file="$(find ur_modern_driver)/launch/ur_common.launch">
     <arg name="robot_ip" value="$(arg robot_ip)"/>
+    <arg name="reverse_ip" value="$(arg reverse_ip)"/>
     <arg name="reverse_port" value="$(arg reverse_port)"/>
     <arg name="min_payload"  value="$(arg min_payload)"/>
     <arg name="max_payload"  value="$(arg max_payload)"/>

--- a/launch/ur10e_bringup.launch
+++ b/launch/ur10e_bringup.launch
@@ -10,7 +10,7 @@
 
   <!-- robot_ip: IP-address of the robot's socket-messaging server -->
   <arg name="robot_ip"/>
-	<arg name="reverse_port" default="50001"/>
+  <arg name="reverse_port" default="50001"/>
   <arg name="limited" default="false"/>
   <arg name="min_payload"  default="0.0"/>
   <arg name="max_payload"  default="10.0"/>

--- a/launch/ur10e_bringup.launch
+++ b/launch/ur10e_bringup.launch
@@ -16,7 +16,7 @@
   <arg name="min_payload"  default="0.0"/>
   <arg name="max_payload"  default="10.0"/>
   <arg name="prefix" default="" />
-  <arg name="use_lowbandwidth_trajectory_follower" default="false"/>
+  <arg name="use_lowbandwidth_trajectory_follower" default="true"/>
   <arg name="time_interval" default="0.008"/>
   <arg name="servoj_time" default="0.008" />
   <arg name="servoj_time_waiting" default="0.001" />

--- a/launch/ur10e_bringup.launch
+++ b/launch/ur10e_bringup.launch
@@ -10,6 +10,7 @@
 
   <!-- robot_ip: IP-address of the robot's socket-messaging server -->
   <arg name="robot_ip"/>
+	<arg name="reverse_port" default="50001"/>
   <arg name="limited" default="false"/>
   <arg name="min_payload"  default="0.0"/>
   <arg name="max_payload"  default="10.0"/>
@@ -33,6 +34,7 @@
   <!-- ur common -->
   <include file="$(find ur_modern_driver)/launch/ur_common.launch">
     <arg name="robot_ip" value="$(arg robot_ip)"/>
+    <arg name="reverse_port" value="$(arg reverse_port)"/>
     <arg name="min_payload"  value="$(arg min_payload)"/>
     <arg name="max_payload"  value="$(arg max_payload)"/>
     <arg name="prefix" default="" />

--- a/launch/ur10e_bringup_compatible.launch
+++ b/launch/ur10e_bringup_compatible.launch
@@ -1,0 +1,53 @@
+<?xml version="1.0"?>
+<!--
+  Universal robot ur10e launch.  Loads ur10e robot description (see ur_common.launch
+  for more info)
+
+  Usage:
+    ur10e_bringup.launch robot_ip:=<value>
+-->
+<launch>
+
+  <!-- robot_ip: IP-address of the robot's socket-messaging server -->
+  <arg name="robot_ip"/>
+  <arg name="limited" default="false"/>
+  <arg name="min_payload"  default="0.0"/>
+  <arg name="max_payload"  default="10.0"/>
+  <arg name="prefix" default="" />
+  <arg name="use_lowbandwidth_trajectory_follower" default="false"/>
+  <arg name="time_interval" default="0.08"/>
+  <arg name="servoj_time" default="0.08" />
+  <arg name="servoj_time_waiting" default="0.001" />
+  <arg name="max_waiting_time" default="2.0" />
+  <arg name="servoj_gain" default="100." />
+  <arg name="servoj_lookahead_time" default="1." />
+  <arg name="max_joint_difference" default="0.01" />
+  <arg name="base_frame" default="$(arg prefix)base" />
+  <arg name="tool_frame" default="$(arg prefix)tool0_controller" />
+  <arg name="shutdown_on_disconnect" default="true" />
+
+  <!-- robot model -->
+  <include file="$(find ur_e_description)/launch/ur10e_upload.launch">
+    <arg name="limited" value="$(arg limited)"/>
+  </include>
+
+  <!-- ur common -->
+  <include file="$(find ur_modern_driver)/launch/ur_common.launch">
+    <arg name="robot_ip" value="$(arg robot_ip)"/>
+    <arg name="min_payload"  value="$(arg min_payload)"/>
+    <arg name="max_payload"  value="$(arg max_payload)"/>
+    <arg name="prefix" default="" />
+    <arg name="use_lowbandwidth_trajectory_follower" value="$(arg use_lowbandwidth_trajectory_follower)"/>
+    <arg name="time_interval" value="$(arg time_interval)"/>
+    <arg name="servoj_time" value="$(arg servoj_time)" />
+    <arg name="servoj_time_waiting" default="$(arg servoj_time_waiting)" />
+    <arg name="max_waiting_time" value="$(arg max_waiting_time)" />
+    <arg name="servoj_gain" value="$(arg servoj_gain)" />
+    <arg name="servoj_lookahead_time" value="$(arg servoj_lookahead_time)" />
+    <arg name="max_joint_difference" value="$(arg max_joint_difference)" />
+    <arg name="base_frame" value="$(arg base_frame)" />
+    <arg name="tool_frame" value="$(arg tool_frame)" />
+    <arg name="shutdown_on_disconnect" value="$(arg shutdown_on_disconnect)"/>
+  </include>
+
+</launch>

--- a/launch/ur10e_bringup_compatible.launch
+++ b/launch/ur10e_bringup_compatible.launch
@@ -10,6 +10,7 @@
 
   <!-- robot_ip: IP-address of the robot's socket-messaging server -->
   <arg name="robot_ip"/>
+  <arg name="reverse_ip" default="" doc="IP of the computer running the driver" />
   <arg name="reverse_port" default="50001"/>
   <arg name="limited" default="false"/>
   <arg name="min_payload"  default="0.0"/>
@@ -35,6 +36,7 @@
   <!-- ur common -->
   <include file="$(find ur_modern_driver)/launch/ur_common.launch">
     <arg name="robot_ip" value="$(arg robot_ip)"/>
+    <arg name="reverse_ip" value="$(arg reverse_ip)"/>
     <arg name="reverse_port" value="$(arg reverse_port)"/>
     <arg name="min_payload"  value="$(arg min_payload)"/>
     <arg name="max_payload"  value="$(arg max_payload)"/>

--- a/launch/ur10e_bringup_compatible.launch
+++ b/launch/ur10e_bringup_compatible.launch
@@ -10,6 +10,7 @@
 
   <!-- robot_ip: IP-address of the robot's socket-messaging server -->
   <arg name="robot_ip"/>
+	<arg name="reverse_port" default="50001"/>
   <arg name="limited" default="false"/>
   <arg name="min_payload"  default="0.0"/>
   <arg name="max_payload"  default="10.0"/>
@@ -34,6 +35,7 @@
   <!-- ur common -->
   <include file="$(find ur_modern_driver)/launch/ur_common.launch">
     <arg name="robot_ip" value="$(arg robot_ip)"/>
+    <arg name="reverse_port" value="$(arg reverse_port)"/>
     <arg name="min_payload"  value="$(arg min_payload)"/>
     <arg name="max_payload"  value="$(arg max_payload)"/>
     <arg name="prefix" default="" />

--- a/launch/ur10e_bringup_compatible.launch
+++ b/launch/ur10e_bringup_compatible.launch
@@ -10,7 +10,7 @@
 
   <!-- robot_ip: IP-address of the robot's socket-messaging server -->
   <arg name="robot_ip"/>
-	<arg name="reverse_port" default="50001"/>
+  <arg name="reverse_port" default="50001"/>
   <arg name="limited" default="false"/>
   <arg name="min_payload"  default="0.0"/>
   <arg name="max_payload"  default="10.0"/>

--- a/launch/ur10e_bringup_joint_limited.launch
+++ b/launch/ur10e_bringup_joint_limited.launch
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<!--
+  Universal robot ur10e launch. Wraps ur10e_bringup.launch. Uses the 'limited'
+  joint range [-PI, PI] on all joints.
+
+  Usage:
+    ur10e_bringup_joint_limited.launch robot_ip:=<value>
+-->
+<launch>
+
+  <!-- robot_ip: IP-address of the robot's socket-messaging server -->
+  <arg name="robot_ip"/>
+  <arg name="min_payload"  default="0.0"/>
+  <arg name="max_payload"  default="10.0"/>
+  <arg name="prefix" default="" />
+  <arg name="use_lowbandwidth_trajectory_follower" default="false"/>
+  <arg name="time_interval" default="0.008"/>
+  <arg name="servoj_time" default="0.008" />
+  <arg name="servoj_time_waiting" default="0.001" />
+  <arg name="max_waiting_time" default="2.0" />
+  <arg name="servoj_gain" default="100." />
+  <arg name="servoj_lookahead_time" default="1." />
+  <arg name="max_joint_difference" default="0.01" />
+  <arg name="base_frame" default="$(arg prefix)base" />
+  <arg name="tool_frame" default="$(arg prefix)tool0_controller" />
+  <arg name="shutdown_on_disconnect" default="true" />
+
+  <include file="$(find ur_modern_driver)/launch/ur10e_bringup.launch">
+    <arg name="robot_ip" value="$(arg robot_ip)"/>
+    <arg name="limited"  value="true"/>
+    <arg name="min_payload"  value="$(arg min_payload)"/>
+    <arg name="max_payload"  value="$(arg max_payload)"/>
+    <arg name="prefix" value="$(arg prefix)" />
+    <arg name="use_lowbandwidth_trajectory_follower" value="$(arg use_lowbandwidth_trajectory_follower)"/>
+    <arg name="time_interval" value="$(arg time_interval)"/>
+    <arg name="servoj_time" value="$(arg servoj_time)" />
+    <arg name="servoj_time_waiting" default="$(arg servoj_time_waiting)" />
+    <arg name="max_waiting_time" value="$(arg max_waiting_time)" />
+    <arg name="servoj_gain" value="$(arg servoj_gain)" />
+    <arg name="servoj_lookahead_time" value="$(arg servoj_lookahead_time)" />
+    <arg name="max_joint_difference" value="$(arg max_joint_difference)" />
+    <arg name="base_frame" value="$(arg base_frame)" />
+    <arg name="tool_frame" value="$(arg tool_frame)" />
+    <arg name="shutdown_on_disconnect" value="$(arg shutdown_on_disconnect)"/>
+  </include>
+</launch>

--- a/launch/ur10e_bringup_joint_limited.launch
+++ b/launch/ur10e_bringup_joint_limited.launch
@@ -10,6 +10,7 @@
 
   <!-- robot_ip: IP-address of the robot's socket-messaging server -->
   <arg name="robot_ip"/>
+	<arg name="reverse_port" default="50001"/>
   <arg name="min_payload"  default="0.0"/>
   <arg name="max_payload"  default="10.0"/>
   <arg name="prefix" default="" />
@@ -27,6 +28,7 @@
 
   <include file="$(find ur_modern_driver)/launch/ur10e_bringup.launch">
     <arg name="robot_ip" value="$(arg robot_ip)"/>
+    <arg name="reverse_port" value="$(arg reverse_port)"/>
     <arg name="limited"  value="true"/>
     <arg name="min_payload"  value="$(arg min_payload)"/>
     <arg name="max_payload"  value="$(arg max_payload)"/>

--- a/launch/ur10e_bringup_joint_limited.launch
+++ b/launch/ur10e_bringup_joint_limited.launch
@@ -10,7 +10,7 @@
 
   <!-- robot_ip: IP-address of the robot's socket-messaging server -->
   <arg name="robot_ip"/>
-	<arg name="reverse_port" default="50001"/>
+  <arg name="reverse_port" default="50001"/>
   <arg name="min_payload"  default="0.0"/>
   <arg name="max_payload"  default="10.0"/>
   <arg name="prefix" default="" />

--- a/launch/ur10e_bringup_joint_limited.launch
+++ b/launch/ur10e_bringup_joint_limited.launch
@@ -10,6 +10,7 @@
 
   <!-- robot_ip: IP-address of the robot's socket-messaging server -->
   <arg name="robot_ip"/>
+  <arg name="reverse_ip" default="" doc="IP of the computer running the driver" />
   <arg name="reverse_port" default="50001"/>
   <arg name="min_payload"  default="0.0"/>
   <arg name="max_payload"  default="10.0"/>
@@ -28,6 +29,7 @@
 
   <include file="$(find ur_modern_driver)/launch/ur10e_bringup.launch">
     <arg name="robot_ip" value="$(arg robot_ip)"/>
+    <arg name="reverse_ip" value="$(arg reverse_ip)"/>
     <arg name="reverse_port" value="$(arg reverse_port)"/>
     <arg name="limited"  value="true"/>
     <arg name="min_payload"  value="$(arg min_payload)"/>

--- a/launch/ur10e_bringup_joint_limited.launch
+++ b/launch/ur10e_bringup_joint_limited.launch
@@ -15,7 +15,7 @@
   <arg name="min_payload"  default="0.0"/>
   <arg name="max_payload"  default="10.0"/>
   <arg name="prefix" default="" />
-  <arg name="use_lowbandwidth_trajectory_follower" default="false"/>
+  <arg name="use_lowbandwidth_trajectory_follower" default="true"/>
   <arg name="time_interval" default="0.008"/>
   <arg name="servoj_time" default="0.008" />
   <arg name="servoj_time_waiting" default="0.001" />

--- a/launch/ur10e_ros_control.launch
+++ b/launch/ur10e_ros_control.launch
@@ -1,0 +1,52 @@
+<?xml version="1.0"?>
+<launch>
+
+  <!-- GDB functionality -->
+  <arg name="debug" default="false" />
+  <arg unless="$(arg debug)" name="launch_prefix" value="" />
+  <arg     if="$(arg debug)" name="launch_prefix" value="gdb --ex run --args" />
+
+  <arg name="robot_ip"/>
+  <arg name="limited" default="false"/>
+  <arg name="min_payload"  default="0.0"/>
+  <arg name="max_payload"  default="3.0"/>
+  <arg name="prefix" default="" />  
+  <arg name="max_velocity" default="10.0"/> <!-- [rad/s] -->
+  <arg name="base_frame" default="$(arg prefix)base" />
+  <arg name="tool_frame" default="$(arg prefix)tool0_controller" />
+  <arg name="shutdown_on_disconnect" default="true" />
+  <!-- robot model -->
+  <include file="$(find ur_e_description)/launch/ur10e_upload.launch">
+    <arg name="limited" value="$(arg limited)"/>
+  </include>
+
+
+  <!-- Load hardware interface -->
+  <node name="ur_hardware_interface" pkg="ur_modern_driver" type="ur_driver" output="log" launch-prefix="$(arg launch_prefix)">
+    <param name="robot_ip_address" type="str" value="$(arg robot_ip)"/>
+    <param name="min_payload" type="double" value="$(arg min_payload)"/>
+    <param name="max_payload" type="double" value="$(arg max_payload)"/>
+    <param name="max_velocity" type="double" value="$(arg max_velocity)"/>
+    <param name="use_ros_control" type="bool" value="True"/>
+    <param name="servoj_gain" type="double" value="750" />
+    <param name="prefix" value="$(arg prefix)" />
+    <param name="base_frame" type="str" value="$(arg base_frame)"/>
+    <param name="tool_frame" type="str" value="$(arg tool_frame)"/>
+    <param name="shutdown_on_disconnect" type="bool" value="$(arg shutdown_on_disconnect)"/>
+  </node>
+
+  <!-- Load controller settings -->
+  <rosparam file="$(find ur_modern_driver)/config/ur10_controllers.yaml" command="load"/>
+
+  <!-- spawn controller manager -->
+  <node name="ros_control_controller_spawner" pkg="controller_manager" type="spawner" respawn="false"
+    output="screen" args="joint_state_controller force_torque_sensor_controller vel_based_pos_traj_controller" />
+
+  <!-- load other controller --> 
+  <node name="ros_control_controller_manager" pkg="controller_manager" type="controller_manager" respawn="false"
+    output="screen" args="load pos_based_pos_traj_controller" /> 
+
+  <!-- Convert joint states to /tf tranforms -->
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>
+
+</launch>

--- a/launch/ur10e_ros_control.launch
+++ b/launch/ur10e_ros_control.launch
@@ -7,23 +7,26 @@
   <arg     if="$(arg debug)" name="launch_prefix" value="gdb --ex run --args" />
 
   <arg name="robot_ip"/>
+	<arg name="reverse_port" default="50001"/>
   <arg name="limited" default="false"/>
   <arg name="min_payload"  default="0.0"/>
   <arg name="max_payload"  default="3.0"/>
-  <arg name="prefix" default="" />  
+  <arg name="prefix" default="" />
   <arg name="max_velocity" default="10.0"/> <!-- [rad/s] -->
   <arg name="base_frame" default="$(arg prefix)base" />
   <arg name="tool_frame" default="$(arg prefix)tool0_controller" />
   <arg name="shutdown_on_disconnect" default="true" />
+  <arg name="controllers" default="joint_state_controller force_torque_sensor_controller vel_based_pos_traj_controller"/>
+  <arg name="stopped_controllers" default="pos_based_pos_traj_controller joint_group_vel_controller"/>
   <!-- robot model -->
   <include file="$(find ur_e_description)/launch/ur10e_upload.launch">
     <arg name="limited" value="$(arg limited)"/>
   </include>
 
-
   <!-- Load hardware interface -->
   <node name="ur_hardware_interface" pkg="ur_modern_driver" type="ur_driver" output="log" launch-prefix="$(arg launch_prefix)">
     <param name="robot_ip_address" type="str" value="$(arg robot_ip)"/>
+    <param name="reverse_port" type="int" value="$(arg reverse_port)" />
     <param name="min_payload" type="double" value="$(arg min_payload)"/>
     <param name="max_payload" type="double" value="$(arg max_payload)"/>
     <param name="max_velocity" type="double" value="$(arg max_velocity)"/>
@@ -40,12 +43,12 @@
 
   <!-- spawn controller manager -->
   <node name="ros_control_controller_spawner" pkg="controller_manager" type="spawner" respawn="false"
-    output="screen" args="joint_state_controller force_torque_sensor_controller vel_based_pos_traj_controller" />
+    output="screen" args="$(arg controllers)" />
 
-  <!-- load other controller --> 
+  <!-- load other controller -->
   <node name="ros_control_controller_manager" pkg="controller_manager" type="controller_manager" respawn="false"
-    output="screen" args="load pos_based_pos_traj_controller" /> 
-
+    output="screen" args="load $(arg stopped_controllers)" />
+    
   <!-- Convert joint states to /tf tranforms -->
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>
 

--- a/launch/ur10e_ros_control.launch
+++ b/launch/ur10e_ros_control.launch
@@ -7,7 +7,7 @@
   <arg     if="$(arg debug)" name="launch_prefix" value="gdb --ex run --args" />
 
   <arg name="robot_ip"/>
-	<arg name="reverse_port" default="50001"/>
+  <arg name="reverse_port" default="50001"/>
   <arg name="limited" default="false"/>
   <arg name="min_payload"  default="0.0"/>
   <arg name="max_payload"  default="3.0"/>
@@ -48,7 +48,7 @@
   <!-- load other controller -->
   <node name="ros_control_controller_manager" pkg="controller_manager" type="controller_manager" respawn="false"
     output="screen" args="load $(arg stopped_controllers)" />
-    
+
   <!-- Convert joint states to /tf tranforms -->
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>
 

--- a/launch/ur10e_ros_control.launch
+++ b/launch/ur10e_ros_control.launch
@@ -7,6 +7,7 @@
   <arg     if="$(arg debug)" name="launch_prefix" value="gdb --ex run --args" />
 
   <arg name="robot_ip"/>
+  <arg name="reverse_ip" default="" doc="IP of the computer running the driver" />
   <arg name="reverse_port" default="50001"/>
   <arg name="limited" default="false"/>
   <arg name="min_payload"  default="0.0"/>
@@ -26,6 +27,7 @@
   <!-- Load hardware interface -->
   <node name="ur_hardware_interface" pkg="ur_modern_driver" type="ur_driver" output="log" launch-prefix="$(arg launch_prefix)">
     <param name="robot_ip_address" type="str" value="$(arg robot_ip)"/>
+    <param name="reverse_ip_address" type="str" value="$(arg reverse_ip)" />
     <param name="reverse_port" type="int" value="$(arg reverse_port)" />
     <param name="min_payload" type="double" value="$(arg min_payload)"/>
     <param name="max_payload" type="double" value="$(arg max_payload)"/>

--- a/launch/ur3e_bringup.launch
+++ b/launch/ur3e_bringup.launch
@@ -1,0 +1,52 @@
+<?xml version="1.0"?>
+<!--
+  Universal robot ur3e launch.  Loads ur3e robot description (see ur_common.launch
+  for more info)
+
+  Usage:
+    ur3e_bringup.launch robot_ip:=<value>
+-->
+<launch>
+
+  <!-- robot_ip: IP-address of the robot's socket-messaging server -->
+  <arg name="robot_ip"/>
+  <arg name="limited" default="false"/>
+  <arg name="min_payload"  default="0.0"/>
+  <arg name="max_payload"  default="3.0"/>
+  <arg name="prefix" default="" />
+  <arg name="use_lowbandwidth_trajectory_follower" default="false"/>
+  <arg name="time_interval" default="0.008"/>
+  <arg name="servoj_time" default="0.008" />
+  <arg name="servoj_time_waiting" default="0.001" />
+  <arg name="max_waiting_time" default="2.0" />
+  <arg name="servoj_gain" default="100." />
+  <arg name="servoj_lookahead_time" default="1." />
+  <arg name="max_joint_difference" default="0.01" />
+  <arg name="base_frame" default="$(arg prefix)base" />
+  <arg name="tool_frame" default="$(arg prefix)tool0_controller" />
+  <arg name="shutdown_on_disconnect" default="true" />
+  <!-- robot model -->
+  <include file="$(find ur_e_description)/launch/ur3e_upload.launch">
+    <arg name="limited" value="$(arg limited)"/>
+  </include>
+
+  <!-- ur common -->
+  <include file="$(find ur_modern_driver)/launch/ur_common.launch">
+    <arg name="robot_ip" value="$(arg robot_ip)"/>
+    <arg name="min_payload"  value="$(arg min_payload)"/>
+    <arg name="max_payload"  value="$(arg max_payload)"/>
+    <arg name="prefix" value="$(arg prefix)" />
+    <arg name="use_lowbandwidth_trajectory_follower" value="$(arg use_lowbandwidth_trajectory_follower)"/>
+    <arg name="time_interval" value="$(arg time_interval)"/>
+    <arg name="servoj_time" value="$(arg servoj_time)" />
+    <arg name="servoj_time_waiting" default="$(arg servoj_time_waiting)" />
+    <arg name="max_waiting_time" value="$(arg max_waiting_time)" />
+    <arg name="servoj_gain" value="$(arg servoj_gain)" />
+    <arg name="servoj_lookahead_time" value="$(arg servoj_lookahead_time)" />
+    <arg name="max_joint_difference" value="$(arg max_joint_difference)" />
+    <arg name="base_frame" value="$(arg base_frame)" />
+    <arg name="tool_frame" value="$(arg tool_frame)" />
+    <arg name="shutdown_on_disconnect" value="$(arg shutdown_on_disconnect)"/>
+  </include>
+
+</launch>

--- a/launch/ur3e_bringup.launch
+++ b/launch/ur3e_bringup.launch
@@ -10,6 +10,7 @@
 
   <!-- robot_ip: IP-address of the robot's socket-messaging server -->
   <arg name="robot_ip"/>
+	<arg name="reverse_port" default="50001"/>
   <arg name="limited" default="false"/>
   <arg name="min_payload"  default="0.0"/>
   <arg name="max_payload"  default="3.0"/>
@@ -33,6 +34,7 @@
   <!-- ur common -->
   <include file="$(find ur_modern_driver)/launch/ur_common.launch">
     <arg name="robot_ip" value="$(arg robot_ip)"/>
+    <arg name="reverse_port" value="$(arg reverse_port)"/>
     <arg name="min_payload"  value="$(arg min_payload)"/>
     <arg name="max_payload"  value="$(arg max_payload)"/>
     <arg name="prefix" value="$(arg prefix)" />

--- a/launch/ur3e_bringup.launch
+++ b/launch/ur3e_bringup.launch
@@ -10,7 +10,7 @@
 
   <!-- robot_ip: IP-address of the robot's socket-messaging server -->
   <arg name="robot_ip"/>
-	<arg name="reverse_port" default="50001"/>
+  <arg name="reverse_port" default="50001"/>
   <arg name="limited" default="false"/>
   <arg name="min_payload"  default="0.0"/>
   <arg name="max_payload"  default="3.0"/>

--- a/launch/ur3e_bringup.launch
+++ b/launch/ur3e_bringup.launch
@@ -10,6 +10,7 @@
 
   <!-- robot_ip: IP-address of the robot's socket-messaging server -->
   <arg name="robot_ip"/>
+  <arg name="reverse_ip" default="" doc="IP of the computer running the driver" />
   <arg name="reverse_port" default="50001"/>
   <arg name="limited" default="false"/>
   <arg name="min_payload"  default="0.0"/>
@@ -34,6 +35,7 @@
   <!-- ur common -->
   <include file="$(find ur_modern_driver)/launch/ur_common.launch">
     <arg name="robot_ip" value="$(arg robot_ip)"/>
+    <arg name="reverse_ip" value="$(arg reverse_ip)"/>
     <arg name="reverse_port" value="$(arg reverse_port)"/>
     <arg name="min_payload"  value="$(arg min_payload)"/>
     <arg name="max_payload"  value="$(arg max_payload)"/>

--- a/launch/ur3e_bringup_joint_limited.launch
+++ b/launch/ur3e_bringup_joint_limited.launch
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<!--
+  Universal robot ur3e launch. Wraps ur3e_bringup.launch. Uses the 'limited'
+  joint range [-PI, PI] on all joints.
+
+  Usage:
+    ur3e_bringup_joint_limited.launch robot_ip:=<value>
+-->
+<launch>
+
+  <!-- robot_ip: IP-address of the robot's socket-messaging server -->
+  <arg name="robot_ip"/>
+  <arg name="min_payload"  default="0.0"/>
+  <arg name="max_payload"  default="3.0"/>
+  <arg name="prefix" default="" />
+  <arg name="use_lowbandwidth_trajectory_follower" default="false"/>
+  <arg name="time_interval" default="0.008"/>
+  <arg name="servoj_time" default="0.008" />
+  <arg name="servoj_time_waiting" default="0.001" />
+  <arg name="max_waiting_time" default="2.0" />
+  <arg name="servoj_gain" default="100." />
+  <arg name="servoj_lookahead_time" default="1." />
+  <arg name="max_joint_difference" default="0.01" />
+  <arg name="base_frame" default="$(arg prefix)base" />
+  <arg name="tool_frame" default="$(arg prefix)tool0_controller" />
+  <arg name="shutdown_on_disconnect" default="true" />
+
+  <include file="$(find ur_modern_driver)/launch/ur3e_bringup.launch">
+    <arg name="robot_ip" value="$(arg robot_ip)"/>
+    <arg name="limited"  value="true"/>
+    <arg name="min_payload"  value="$(arg min_payload)"/>
+    <arg name="max_payload"  value="$(arg max_payload)"/>
+    <arg name="prefix" value="$(arg prefix)" />
+    <arg name="use_lowbandwidth_trajectory_follower" value="$(arg use_lowbandwidth_trajectory_follower)"/>
+    <arg name="time_interval" value="$(arg time_interval)"/>
+    <arg name="servoj_time" value="$(arg servoj_time)" />
+    <arg name="servoj_time_waiting" default="$(arg servoj_time_waiting)" />
+    <arg name="max_waiting_time" value="$(arg max_waiting_time)" />
+    <arg name="servoj_gain" value="$(arg servoj_gain)" />
+    <arg name="servoj_lookahead_time" value="$(arg servoj_lookahead_time)" />
+    <arg name="max_joint_difference" value="$(arg max_joint_difference)" />
+    <arg name="base_frame" value="$(arg base_frame)" />
+    <arg name="tool_frame" value="$(arg tool_frame)" />
+    <arg name="shutdown_on_disconnect" value="$(arg shutdown_on_disconnect)"/>
+  </include>
+</launch>

--- a/launch/ur3e_bringup_joint_limited.launch
+++ b/launch/ur3e_bringup_joint_limited.launch
@@ -10,6 +10,7 @@
 
   <!-- robot_ip: IP-address of the robot's socket-messaging server -->
   <arg name="robot_ip"/>
+  <arg name="reverse_ip" default="" doc="IP of the computer running the driver" />
   <arg name="reverse_port" default="50001"/>
   <arg name="min_payload"  default="0.0"/>
   <arg name="max_payload"  default="3.0"/>
@@ -28,6 +29,7 @@
 
   <include file="$(find ur_modern_driver)/launch/ur3e_bringup.launch">
     <arg name="robot_ip" value="$(arg robot_ip)"/>
+    <arg name="reverse_ip" value="$(arg reverse_ip)"/>
     <arg name="reverse_port" value="$(arg reverse_port)"/>
     <arg name="limited"  value="true"/>
     <arg name="min_payload"  value="$(arg min_payload)"/>

--- a/launch/ur3e_bringup_joint_limited.launch
+++ b/launch/ur3e_bringup_joint_limited.launch
@@ -10,6 +10,7 @@
 
   <!-- robot_ip: IP-address of the robot's socket-messaging server -->
   <arg name="robot_ip"/>
+	<arg name="reverse_port" default="50001"/>
   <arg name="min_payload"  default="0.0"/>
   <arg name="max_payload"  default="3.0"/>
   <arg name="prefix" default="" />
@@ -27,6 +28,7 @@
 
   <include file="$(find ur_modern_driver)/launch/ur3e_bringup.launch">
     <arg name="robot_ip" value="$(arg robot_ip)"/>
+    <arg name="reverse_port" value="$(arg reverse_port)"/>
     <arg name="limited"  value="true"/>
     <arg name="min_payload"  value="$(arg min_payload)"/>
     <arg name="max_payload"  value="$(arg max_payload)"/>

--- a/launch/ur3e_bringup_joint_limited.launch
+++ b/launch/ur3e_bringup_joint_limited.launch
@@ -10,7 +10,7 @@
 
   <!-- robot_ip: IP-address of the robot's socket-messaging server -->
   <arg name="robot_ip"/>
-	<arg name="reverse_port" default="50001"/>
+  <arg name="reverse_port" default="50001"/>
   <arg name="min_payload"  default="0.0"/>
   <arg name="max_payload"  default="3.0"/>
   <arg name="prefix" default="" />

--- a/launch/ur3e_ros_control.launch
+++ b/launch/ur3e_ros_control.launch
@@ -1,0 +1,52 @@
+<?xml version="1.0"?>
+<launch>
+
+  <!-- GDB functionality -->
+  <arg name="debug" default="false" />
+  <arg unless="$(arg debug)" name="launch_prefix" value="" />
+  <arg     if="$(arg debug)" name="launch_prefix" value="gdb --ex run --args" />
+
+  <arg name="robot_ip"/>
+  <arg name="limited" default="false"/>
+  <arg name="min_payload"  default="0.0"/>
+  <arg name="max_payload"  default="3.0"/>
+  <arg name="prefix" default="" />
+  <arg name="max_velocity" default="10.0"/> <!-- [rad/s] -->
+  <arg name="base_frame" default="$(arg prefix)base" />
+  <arg name="tool_frame" default="$(arg prefix)tool0_controller" />
+  <arg name="shutdown_on_disconnect" default="true" />
+  <!-- robot model -->
+  <include file="$(find ur_e_description)/launch/ur3e_upload.launch">
+    <arg name="limited" value="$(arg limited)"/>
+  </include>
+
+
+  <!-- Load hardware interface -->
+  <node name="ur_hardware_interface" pkg="ur_modern_driver" type="ur_driver" output="log" launch-prefix="$(arg launch_prefix)">
+    <param name="robot_ip_address" type="str" value="$(arg robot_ip)"/>
+    <param name="min_payload" type="double" value="$(arg min_payload)"/>
+    <param name="max_payload" type="double" value="$(arg max_payload)"/>
+    <param name="max_velocity" type="double" value="$(arg max_velocity)"/>
+    <param name="use_ros_control" type="bool" value="True"/>
+    <param name="servoj_gain" type="double" value="750" />
+    <param name="prefix" value="$(arg prefix)" />
+    <param name="base_frame" type="str" value="$(arg base_frame)"/>
+    <param name="tool_frame" type="str" value="$(arg tool_frame)"/>
+    <param name="shutdown_on_disconnect" type="bool" value="$(arg shutdown_on_disconnect)"/>
+  </node>
+
+  <!-- Load controller settings -->
+  <rosparam file="$(find ur_modern_driver)/config/ur3_controllers.yaml" command="load"/>
+
+  <!-- spawn controller manager -->
+  <node name="ros_control_controller_spawner" pkg="controller_manager" type="spawner" respawn="false"
+    output="screen" args="joint_state_controller force_torque_sensor_controller vel_based_pos_traj_controller" />
+
+  <!-- load other controller -->
+  <node name="ros_control_controller_manager" pkg="controller_manager" type="controller_manager" respawn="false"
+    output="screen" args="load pos_based_pos_traj_controller" />
+
+  <!-- Convert joint states to /tf tranforms -->
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>
+
+</launch>

--- a/launch/ur3e_ros_control.launch
+++ b/launch/ur3e_ros_control.launch
@@ -7,6 +7,7 @@
   <arg     if="$(arg debug)" name="launch_prefix" value="gdb --ex run --args" />
 
   <arg name="robot_ip"/>
+  <arg name="reverse_ip" default="" doc="IP of the computer running the driver" />
   <arg name="reverse_port" default="50001"/>
   <arg name="limited" default="false"/>
   <arg name="min_payload"  default="0.0"/>
@@ -27,6 +28,7 @@
   <!-- Load hardware interface -->
   <node name="ur_hardware_interface" pkg="ur_modern_driver" type="ur_driver" output="log" launch-prefix="$(arg launch_prefix)">
     <param name="robot_ip_address" type="str" value="$(arg robot_ip)"/>
+    <arg name="reverse_ip" value="$(arg reverse_ip)"/>
     <param name="reverse_port" type="int" value="$(arg reverse_port)" />
     <param name="min_payload" type="double" value="$(arg min_payload)"/>
     <param name="max_payload" type="double" value="$(arg max_payload)"/>

--- a/launch/ur3e_ros_control.launch
+++ b/launch/ur3e_ros_control.launch
@@ -7,6 +7,7 @@
   <arg     if="$(arg debug)" name="launch_prefix" value="gdb --ex run --args" />
 
   <arg name="robot_ip"/>
+	<arg name="reverse_port" default="50001"/>
   <arg name="limited" default="false"/>
   <arg name="min_payload"  default="0.0"/>
   <arg name="max_payload"  default="3.0"/>
@@ -15,6 +16,8 @@
   <arg name="base_frame" default="$(arg prefix)base" />
   <arg name="tool_frame" default="$(arg prefix)tool0_controller" />
   <arg name="shutdown_on_disconnect" default="true" />
+  <arg name="controllers" default="joint_state_controller force_torque_sensor_controller vel_based_pos_traj_controller"/>
+  <arg name="stopped_controllers" default="pos_based_pos_traj_controller joint_group_vel_controller"/>
   <!-- robot model -->
   <include file="$(find ur_e_description)/launch/ur3e_upload.launch">
     <arg name="limited" value="$(arg limited)"/>
@@ -24,6 +27,7 @@
   <!-- Load hardware interface -->
   <node name="ur_hardware_interface" pkg="ur_modern_driver" type="ur_driver" output="log" launch-prefix="$(arg launch_prefix)">
     <param name="robot_ip_address" type="str" value="$(arg robot_ip)"/>
+    <param name="reverse_port" type="int" value="$(arg reverse_port)" />
     <param name="min_payload" type="double" value="$(arg min_payload)"/>
     <param name="max_payload" type="double" value="$(arg max_payload)"/>
     <param name="max_velocity" type="double" value="$(arg max_velocity)"/>
@@ -40,12 +44,12 @@
 
   <!-- spawn controller manager -->
   <node name="ros_control_controller_spawner" pkg="controller_manager" type="spawner" respawn="false"
-    output="screen" args="joint_state_controller force_torque_sensor_controller vel_based_pos_traj_controller" />
+    output="screen" args="$(arg controllers)" />
 
   <!-- load other controller -->
   <node name="ros_control_controller_manager" pkg="controller_manager" type="controller_manager" respawn="false"
-    output="screen" args="load pos_based_pos_traj_controller" />
-
+    output="screen" args="load $(arg stopped_controllers)" />
+    
   <!-- Convert joint states to /tf tranforms -->
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>
 

--- a/launch/ur3e_ros_control.launch
+++ b/launch/ur3e_ros_control.launch
@@ -7,7 +7,7 @@
   <arg     if="$(arg debug)" name="launch_prefix" value="gdb --ex run --args" />
 
   <arg name="robot_ip"/>
-	<arg name="reverse_port" default="50001"/>
+  <arg name="reverse_port" default="50001"/>
   <arg name="limited" default="false"/>
   <arg name="min_payload"  default="0.0"/>
   <arg name="max_payload"  default="3.0"/>
@@ -49,7 +49,7 @@
   <!-- load other controller -->
   <node name="ros_control_controller_manager" pkg="controller_manager" type="controller_manager" respawn="false"
     output="screen" args="load $(arg stopped_controllers)" />
-    
+
   <!-- Convert joint states to /tf tranforms -->
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>
 

--- a/launch/ur5e_bringup.launch
+++ b/launch/ur5e_bringup.launch
@@ -1,0 +1,52 @@
+<?xml version="1.0"?>
+<!--
+  Universal robot ur5e launch.  Loads ur5e robot description (see ur_common.launch
+  for more info)
+
+  Usage:
+    ur5e_bringup.launch robot_ip:=<value>
+-->
+<launch>
+
+  <!-- robot_ip: IP-address of the robot's socket-messaging server -->
+  <arg name="robot_ip"/>
+  <arg name="limited" default="false"/>
+  <arg name="min_payload"  default="0.0"/>
+  <arg name="max_payload"  default="5.0"/>
+  <arg name="prefix" default="" />
+  <arg name="use_lowbandwidth_trajectory_follower" default="false"/>
+  <arg name="time_interval" default="0.008"/>
+  <arg name="servoj_time" default="0.008" />
+  <arg name="servoj_time_waiting" default="0.001" />
+  <arg name="max_waiting_time" default="2.0" />
+  <arg name="servoj_gain" default="100." />
+  <arg name="servoj_lookahead_time" default="1." />
+  <arg name="max_joint_difference" default="0.01" />
+  <arg name="base_frame" default="$(arg prefix)base" />
+  <arg name="tool_frame" default="$(arg prefix)tool0_controller" />
+  <arg name="shutdown_on_disconnect" default="true" />
+  <!-- robot model -->
+  <include file="$(find ur_e_description)/launch/ur5e_upload.launch">
+    <arg name="limited" value="$(arg limited)"/>
+  </include>
+
+  <!-- ur common -->
+  <include file="$(find ur_modern_driver)/launch/ur_common.launch">
+    <arg name="robot_ip" value="$(arg robot_ip)"/>
+    <arg name="min_payload"  value="$(arg min_payload)"/>
+    <arg name="max_payload"  value="$(arg max_payload)"/>
+    <arg name="prefix"  value="$(arg prefix)" />
+    <arg name="use_lowbandwidth_trajectory_follower" value="$(arg use_lowbandwidth_trajectory_follower)"/>
+    <arg name="time_interval" value="$(arg time_interval)"/>
+    <arg name="servoj_time" value="$(arg servoj_time)" />
+    <arg name="servoj_time_waiting" default="$(arg servoj_time_waiting)" />
+    <arg name="max_waiting_time" value="$(arg max_waiting_time)" />
+    <arg name="servoj_gain" value="$(arg servoj_gain)" />
+    <arg name="servoj_lookahead_time" value="$(arg servoj_lookahead_time)" />
+    <arg name="max_joint_difference" value="$(arg max_joint_difference)" />
+    <arg name="base_frame" value="$(arg base_frame)" />
+    <arg name="tool_frame" value="$(arg tool_frame)" />
+    <arg name="shutdown_on_disconnect" value="$(arg shutdown_on_disconnect)"/>
+  </include>
+
+</launch>

--- a/launch/ur5e_bringup.launch
+++ b/launch/ur5e_bringup.launch
@@ -10,7 +10,7 @@
 
   <!-- robot_ip: IP-address of the robot's socket-messaging server -->
   <arg name="robot_ip"/>
-	<arg name="reverse_port" default="50001"/>
+  <arg name="reverse_port" default="50001"/>
   <arg name="limited" default="false"/>
   <arg name="min_payload"  default="0.0"/>
   <arg name="max_payload"  default="5.0"/>

--- a/launch/ur5e_bringup.launch
+++ b/launch/ur5e_bringup.launch
@@ -10,6 +10,7 @@
 
   <!-- robot_ip: IP-address of the robot's socket-messaging server -->
   <arg name="robot_ip"/>
+	<arg name="reverse_port" default="50001"/>
   <arg name="limited" default="false"/>
   <arg name="min_payload"  default="0.0"/>
   <arg name="max_payload"  default="5.0"/>
@@ -33,6 +34,7 @@
   <!-- ur common -->
   <include file="$(find ur_modern_driver)/launch/ur_common.launch">
     <arg name="robot_ip" value="$(arg robot_ip)"/>
+    <arg name="reverse_port" value="$(arg reverse_port)"/>
     <arg name="min_payload"  value="$(arg min_payload)"/>
     <arg name="max_payload"  value="$(arg max_payload)"/>
     <arg name="prefix"  value="$(arg prefix)" />

--- a/launch/ur5e_bringup.launch
+++ b/launch/ur5e_bringup.launch
@@ -10,6 +10,7 @@
 
   <!-- robot_ip: IP-address of the robot's socket-messaging server -->
   <arg name="robot_ip"/>
+  <arg name="reverse_ip" default="" doc="IP of the computer running the driver" />
   <arg name="reverse_port" default="50001"/>
   <arg name="limited" default="false"/>
   <arg name="min_payload"  default="0.0"/>
@@ -34,6 +35,7 @@
   <!-- ur common -->
   <include file="$(find ur_modern_driver)/launch/ur_common.launch">
     <arg name="robot_ip" value="$(arg robot_ip)"/>
+    <arg name="reverse_ip" value="$(arg reverse_ip)"/>
     <arg name="reverse_port" value="$(arg reverse_port)"/>
     <arg name="min_payload"  value="$(arg min_payload)"/>
     <arg name="max_payload"  value="$(arg max_payload)"/>

--- a/launch/ur5e_bringup_compatible.launch
+++ b/launch/ur5e_bringup_compatible.launch
@@ -1,0 +1,53 @@
+<?xml version="1.0"?>
+<!--
+  Universal robot ur5e launch.  Loads ur5e robot description (see ur_common.launch
+  for more info)
+
+  Usage:
+    ur5e_bringup.launch robot_ip:=<value>
+-->
+<launch>
+
+  <!-- robot_ip: IP-address of the robot's socket-messaging server -->
+  <arg name="robot_ip"/>
+  <arg name="limited" default="false"/>
+  <arg name="min_payload"  default="0.0"/>
+  <arg name="max_payload"  default="5.0"/>
+  <arg name="prefix" default="" />
+  <arg name="use_lowbandwidth_trajectory_follower" default="false"/>
+  <arg name="time_interval" default="0.08"/>
+  <arg name="servoj_time" default="0.08" />
+  <arg name="servoj_time_waiting" default="0.001" />
+  <arg name="max_waiting_time" default="2.0" />
+  <arg name="servoj_gain" default="100." />
+  <arg name="servoj_lookahead_time" default="1." />
+  <arg name="max_joint_difference" default="0.01" />
+  <arg name="base_frame" default="$(arg prefix)base" />
+  <arg name="tool_frame" default="$(arg prefix)tool0_controller" />
+  <arg name="shutdown_on_disconnect" default="true" />
+
+  <!-- robot model -->
+  <include file="$(find ur_e_description)/launch/ur5e_upload.launch">
+    <arg name="limited" value="$(arg limited)"/>
+  </include>
+
+  <!-- ur common -->
+  <include file="$(find ur_modern_driver)/launch/ur_common.launch">
+    <arg name="robot_ip" value="$(arg robot_ip)"/>
+    <arg name="min_payload"  value="$(arg min_payload)"/>
+    <arg name="max_payload"  value="$(arg max_payload)"/>
+    <arg name="prefix"  value="$(arg prefix)" />
+    <arg name="use_lowbandwidth_trajectory_follower" value="$(arg use_lowbandwidth_trajectory_follower)"/>
+    <arg name="time_interval" value="$(arg time_interval)"/>
+    <arg name="servoj_time" value="$(arg servoj_time)" />
+    <arg name="servoj_time_waiting" default="$(arg servoj_time_waiting)" />
+    <arg name="max_waiting_time" value="$(arg max_waiting_time)" />
+    <arg name="servoj_gain" value="$(arg servoj_gain)" />
+    <arg name="servoj_lookahead_time" value="$(arg servoj_lookahead_time)" />
+    <arg name="max_joint_difference" value="$(arg max_joint_difference)" />
+    <arg name="base_frame" value="$(arg base_frame)" />
+    <arg name="tool_frame" value="$(arg tool_frame)" />
+    <arg name="shutdown_on_disconnect" value="$(arg shutdown_on_disconnect)"/>
+  </include>
+
+</launch>

--- a/launch/ur5e_bringup_compatible.launch
+++ b/launch/ur5e_bringup_compatible.launch
@@ -10,7 +10,7 @@
 
   <!-- robot_ip: IP-address of the robot's socket-messaging server -->
   <arg name="robot_ip"/>
-	<arg name="reverse_port" default="50001"/>
+  <arg name="reverse_port" default="50001"/>
   <arg name="limited" default="false"/>
   <arg name="min_payload"  default="0.0"/>
   <arg name="max_payload"  default="5.0"/>

--- a/launch/ur5e_bringup_compatible.launch
+++ b/launch/ur5e_bringup_compatible.launch
@@ -10,6 +10,7 @@
 
   <!-- robot_ip: IP-address of the robot's socket-messaging server -->
   <arg name="robot_ip"/>
+	<arg name="reverse_port" default="50001"/>
   <arg name="limited" default="false"/>
   <arg name="min_payload"  default="0.0"/>
   <arg name="max_payload"  default="5.0"/>
@@ -34,6 +35,7 @@
   <!-- ur common -->
   <include file="$(find ur_modern_driver)/launch/ur_common.launch">
     <arg name="robot_ip" value="$(arg robot_ip)"/>
+    <arg name="reverse_port" value="$(arg reverse_port)"/>
     <arg name="min_payload"  value="$(arg min_payload)"/>
     <arg name="max_payload"  value="$(arg max_payload)"/>
     <arg name="prefix"  value="$(arg prefix)" />

--- a/launch/ur5e_bringup_compatible.launch
+++ b/launch/ur5e_bringup_compatible.launch
@@ -10,6 +10,7 @@
 
   <!-- robot_ip: IP-address of the robot's socket-messaging server -->
   <arg name="robot_ip"/>
+  <arg name="reverse_ip" default="" doc="IP of the computer running the driver" />
   <arg name="reverse_port" default="50001"/>
   <arg name="limited" default="false"/>
   <arg name="min_payload"  default="0.0"/>
@@ -35,6 +36,7 @@
   <!-- ur common -->
   <include file="$(find ur_modern_driver)/launch/ur_common.launch">
     <arg name="robot_ip" value="$(arg robot_ip)"/>
+    <arg name="reverse_ip" value="$(arg reverse_ip)"/>
     <arg name="reverse_port" value="$(arg reverse_port)"/>
     <arg name="min_payload"  value="$(arg min_payload)"/>
     <arg name="max_payload"  value="$(arg max_payload)"/>

--- a/launch/ur5e_bringup_joint_limited.launch
+++ b/launch/ur5e_bringup_joint_limited.launch
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<!--
+  Universal robot ur5e launch. Wraps ur5e_bringup.launch. Uses the 'limited'
+  joint range [-PI, PI] on all joints.
+
+  Usage:
+    ur5e_bringup_joint_limited.launch robot_ip:=<value>
+-->
+<launch>
+
+  <!-- robot_ip: IP-address of the robot's socket-messaging server -->
+  <arg name="robot_ip"/>
+  <arg name="min_payload"  default="0.0"/>
+  <arg name="max_payload"  default="5.0"/>
+  <arg name="prefix" default="" />
+  <arg name="use_lowbandwidth_trajectory_follower" default="false"/>
+  <arg name="time_interval" default="0.008"/>
+  <arg name="servoj_time" default="0.008" />
+  <arg name="servoj_time_waiting" default="0.001" />
+  <arg name="max_waiting_time" default="2.0" />
+  <arg name="servoj_gain" default="100." />
+  <arg name="servoj_lookahead_time" default="1." />
+  <arg name="max_joint_difference" default="0.01" />
+  <arg name="base_frame" default="$(arg prefix)base" />
+  <arg name="tool_frame" default="$(arg prefix)tool0_controller" />
+  <arg name="shutdown_on_disconnect" default="true" />
+
+  <include file="$(find ur_modern_driver)/launch/ur5e_bringup.launch">
+    <arg name="robot_ip" value="$(arg robot_ip)"/>
+    <arg name="limited"  value="true"/>
+    <arg name="min_payload"  value="$(arg min_payload)"/>
+    <arg name="max_payload"  value="$(arg max_payload)"/>
+    <arg name="prefix" value="$(arg prefix)" />
+    <arg name="use_lowbandwidth_trajectory_follower" value="$(arg use_lowbandwidth_trajectory_follower)"/>
+    <arg name="time_interval" value="$(arg time_interval)"/>
+    <arg name="servoj_time" value="$(arg servoj_time)" />
+    <arg name="servoj_time_waiting" default="$(arg servoj_time_waiting)" />
+    <arg name="max_waiting_time" value="$(arg max_waiting_time)" />
+    <arg name="servoj_gain" value="$(arg servoj_gain)" />
+    <arg name="servoj_lookahead_time" value="$(arg servoj_lookahead_time)" />
+    <arg name="max_joint_difference" value="$(arg max_joint_difference)" />
+    <arg name="base_frame" value="$(arg base_frame)" />
+    <arg name="tool_frame" value="$(arg tool_frame)" />
+    <arg name="shutdown_on_disconnect" value="$(arg shutdown_on_disconnect)"/>
+  </include>
+</launch>

--- a/launch/ur5e_bringup_joint_limited.launch
+++ b/launch/ur5e_bringup_joint_limited.launch
@@ -10,6 +10,7 @@
 
   <!-- robot_ip: IP-address of the robot's socket-messaging server -->
   <arg name="robot_ip"/>
+	<arg name="reverse_port" default="50001"/>
   <arg name="min_payload"  default="0.0"/>
   <arg name="max_payload"  default="5.0"/>
   <arg name="prefix" default="" />
@@ -27,6 +28,7 @@
 
   <include file="$(find ur_modern_driver)/launch/ur5e_bringup.launch">
     <arg name="robot_ip" value="$(arg robot_ip)"/>
+    <arg name="reverse_port" value="$(arg reverse_port)"/>
     <arg name="limited"  value="true"/>
     <arg name="min_payload"  value="$(arg min_payload)"/>
     <arg name="max_payload"  value="$(arg max_payload)"/>

--- a/launch/ur5e_bringup_joint_limited.launch
+++ b/launch/ur5e_bringup_joint_limited.launch
@@ -10,6 +10,7 @@
 
   <!-- robot_ip: IP-address of the robot's socket-messaging server -->
   <arg name="robot_ip"/>
+  <arg name="reverse_ip" default="" doc="IP of the computer running the driver" />
   <arg name="reverse_port" default="50001"/>
   <arg name="min_payload"  default="0.0"/>
   <arg name="max_payload"  default="5.0"/>
@@ -28,6 +29,7 @@
 
   <include file="$(find ur_modern_driver)/launch/ur5e_bringup.launch">
     <arg name="robot_ip" value="$(arg robot_ip)"/>
+    <arg name="reverse_ip" value="$(arg reverse_ip)"/>
     <arg name="reverse_port" value="$(arg reverse_port)"/>
     <arg name="limited"  value="true"/>
     <arg name="min_payload"  value="$(arg min_payload)"/>

--- a/launch/ur5e_bringup_joint_limited.launch
+++ b/launch/ur5e_bringup_joint_limited.launch
@@ -10,7 +10,7 @@
 
   <!-- robot_ip: IP-address of the robot's socket-messaging server -->
   <arg name="robot_ip"/>
-	<arg name="reverse_port" default="50001"/>
+  <arg name="reverse_port" default="50001"/>
   <arg name="min_payload"  default="0.0"/>
   <arg name="max_payload"  default="5.0"/>
   <arg name="prefix" default="" />

--- a/launch/ur5e_ros_control.launch
+++ b/launch/ur5e_ros_control.launch
@@ -1,0 +1,53 @@
+<?xml version="1.0"?>
+<launch>
+
+  <!-- GDB functionality -->
+  <arg name="debug" default="false" />
+  <arg unless="$(arg debug)" name="launch_prefix" value="" />
+  <arg     if="$(arg debug)" name="launch_prefix" value="gdb --ex run --args" />
+
+  <arg name="robot_ip"/>
+  <arg name="limited" default="false"/>
+  <arg name="min_payload"  default="0.0"/>
+  <arg name="max_payload"  default="3.0"/>
+  <arg name="prefix" default="" />  
+  <arg name="max_velocity" default="10.0"/> <!-- [rad/s] -->
+  <arg name="base_frame" default="$(arg prefix)base" />
+  <arg name="tool_frame" default="$(arg prefix)tool0_controller" />
+  <arg name="shutdown_on_disconnect" default="true" />
+  <!-- robot model -->
+  <include file="$(find ur_e_description)/launch/ur5e_upload.launch">
+    <arg name="limited" value="$(arg limited)"/>
+  </include>
+
+
+  <!-- Load hardware interface -->
+  <node name="ur_hardware_interface" pkg="ur_modern_driver" type="ur_driver" output="log" launch-prefix="$(arg launch_prefix)">
+    <param name="robot_ip_address" type="str" value="$(arg robot_ip)"/>
+    <param name="min_payload" type="double" value="$(arg min_payload)"/>
+    <param name="max_payload" type="double" value="$(arg max_payload)"/>
+    <param name="max_velocity" type="double" value="$(arg max_velocity)"/>
+    <param name="use_ros_control" type="bool" value="True"/>
+    <param name="servoj_gain" type="double" value="750" />
+    <param name="prefix" value="$(arg prefix)" />
+    <param name="base_frame" type="str" value="$(arg base_frame)"/>
+    <param name="tool_frame" type="str" value="$(arg tool_frame)"/>
+    <param name="shutdown_on_disconnect" type="bool" value="$(arg shutdown_on_disconnect)"/>
+  </node>
+
+  <!-- Load controller settings -->
+  <rosparam file="$(find ur_modern_driver)/config/ur5_controllers.yaml" command="load"/>
+
+  <!-- spawn controller manager -->
+  <node name="ros_control_controller_spawner" pkg="controller_manager" type="spawner" respawn="false"
+    output="screen" args="joint_state_controller force_torque_sensor_controller vel_based_pos_traj_controller" />
+
+  <!-- load other controller --> 
+  <node name="ros_control_controller_manager" pkg="controller_manager" type="controller_manager" respawn="false"
+    output="screen" args="load pos_based_pos_traj_controller" /> 
+
+  <!-- Convert joint states to /tf tranforms -->
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>
+
+</launch>
+

--- a/launch/ur5e_ros_control.launch
+++ b/launch/ur5e_ros_control.launch
@@ -7,14 +7,17 @@
   <arg     if="$(arg debug)" name="launch_prefix" value="gdb --ex run --args" />
 
   <arg name="robot_ip"/>
+	<arg name="reverse_port" default="50001"/>
   <arg name="limited" default="false"/>
   <arg name="min_payload"  default="0.0"/>
   <arg name="max_payload"  default="3.0"/>
-  <arg name="prefix" default="" />  
+  <arg name="prefix" default="" />
   <arg name="max_velocity" default="10.0"/> <!-- [rad/s] -->
   <arg name="base_frame" default="$(arg prefix)base" />
   <arg name="tool_frame" default="$(arg prefix)tool0_controller" />
   <arg name="shutdown_on_disconnect" default="true" />
+  <arg name="controllers" default="joint_state_controller force_torque_sensor_controller vel_based_pos_traj_controller"/>
+  <arg name="stopped_controllers" default="pos_based_pos_traj_controller joint_group_vel_controller"/>
   <!-- robot model -->
   <include file="$(find ur_e_description)/launch/ur5e_upload.launch">
     <arg name="limited" value="$(arg limited)"/>
@@ -24,6 +27,7 @@
   <!-- Load hardware interface -->
   <node name="ur_hardware_interface" pkg="ur_modern_driver" type="ur_driver" output="log" launch-prefix="$(arg launch_prefix)">
     <param name="robot_ip_address" type="str" value="$(arg robot_ip)"/>
+    <param name="reverse_port" type="int" value="$(arg reverse_port)" />
     <param name="min_payload" type="double" value="$(arg min_payload)"/>
     <param name="max_payload" type="double" value="$(arg max_payload)"/>
     <param name="max_velocity" type="double" value="$(arg max_velocity)"/>
@@ -40,14 +44,13 @@
 
   <!-- spawn controller manager -->
   <node name="ros_control_controller_spawner" pkg="controller_manager" type="spawner" respawn="false"
-    output="screen" args="joint_state_controller force_torque_sensor_controller vel_based_pos_traj_controller" />
+    output="screen" args="$(arg controllers)" />
 
-  <!-- load other controller --> 
+  <!-- load other controller -->
   <node name="ros_control_controller_manager" pkg="controller_manager" type="controller_manager" respawn="false"
-    output="screen" args="load pos_based_pos_traj_controller" /> 
-
+    output="screen" args="load $(arg stopped_controllers)" />
+    
   <!-- Convert joint states to /tf tranforms -->
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>
 
 </launch>
-

--- a/launch/ur5e_ros_control.launch
+++ b/launch/ur5e_ros_control.launch
@@ -7,6 +7,7 @@
   <arg     if="$(arg debug)" name="launch_prefix" value="gdb --ex run --args" />
 
   <arg name="robot_ip"/>
+  <arg name="reverse_ip" default="" doc="IP of the computer running the driver" />
   <arg name="reverse_port" default="50001"/>
   <arg name="limited" default="false"/>
   <arg name="min_payload"  default="0.0"/>
@@ -27,6 +28,7 @@
   <!-- Load hardware interface -->
   <node name="ur_hardware_interface" pkg="ur_modern_driver" type="ur_driver" output="log" launch-prefix="$(arg launch_prefix)">
     <param name="robot_ip_address" type="str" value="$(arg robot_ip)"/>
+    <arg name="reverse_ip" value="$(arg reverse_ip)"/>
     <param name="reverse_port" type="int" value="$(arg reverse_port)" />
     <param name="min_payload" type="double" value="$(arg min_payload)"/>
     <param name="max_payload" type="double" value="$(arg max_payload)"/>

--- a/launch/ur5e_ros_control.launch
+++ b/launch/ur5e_ros_control.launch
@@ -7,7 +7,7 @@
   <arg     if="$(arg debug)" name="launch_prefix" value="gdb --ex run --args" />
 
   <arg name="robot_ip"/>
-	<arg name="reverse_port" default="50001"/>
+  <arg name="reverse_port" default="50001"/>
   <arg name="limited" default="false"/>
   <arg name="min_payload"  default="0.0"/>
   <arg name="max_payload"  default="3.0"/>
@@ -49,7 +49,7 @@
   <!-- load other controller -->
   <node name="ros_control_controller_manager" pkg="controller_manager" type="controller_manager" respawn="false"
     output="screen" args="load $(arg stopped_controllers)" />
-    
+
   <!-- Convert joint states to /tf tranforms -->
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>
 

--- a/launch/ur_common.launch
+++ b/launch/ur_common.launch
@@ -9,6 +9,8 @@
 <launch>
   <!-- robot_ip: IP-address of the robot's socket-messaging server -->
   <arg name="robot_ip" />
+  <arg name="reverse_ip" default="" doc="IP of the computer running the driver" />
+  <arg name="reverse_port" default="50001"/>
   <arg name="min_payload" />
   <arg name="max_payload" />
   <arg name="prefix" default="" />
@@ -38,6 +40,8 @@
   <!-- copy the specified IP address to be consistant with ROS-Industrial spec. -->
     <param name="prefix" type="str" value="$(arg prefix)" />
     <param name="robot_ip_address" type="str" value="$(arg robot_ip)" />
+    <param name="reverse_ip_address" type="str" value="$(arg reverse_ip)" />
+    <param name="reverse_port" type="int" value="$(arg reverse_port)" />
     <param name="use_ros_control" type="bool" value="$(arg use_ros_control)"/>
     <param name="use_lowbandwidth_trajectory_follower" type="bool" value="$(arg use_lowbandwidth_trajectory_follower)"/>
     <param name="min_payload" type="double" value="$(arg min_payload)" />

--- a/package.xml
+++ b/package.xml
@@ -33,6 +33,7 @@
   <exec_depend>joint_state_controller</exec_depend>
   <exec_depend>joint_trajectory_controller</exec_depend>
   <exec_depend>ur_description</exec_depend>
+  <exec_depend>ur_e_description</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>velocity_controllers</exec_depend>
 

--- a/src/ros/action_server.cpp
+++ b/src/ros/action_server.cpp
@@ -79,6 +79,10 @@ bool ActionServer::consume(RTState_V3_2__3& state)
 {
   return updateState(state);
 }
+bool ActionServer::consume(RTState_V3_5__5_1& state)
+{
+  return updateState(state);
+}
 
 void ActionServer::onGoal(GoalHandle gh)
 {

--- a/src/ros/action_server.cpp
+++ b/src/ros/action_server.cpp
@@ -83,6 +83,10 @@ bool ActionServer::consume(RTState_V3_5__5_1& state)
 {
   return updateState(state);
 }
+bool ActionServer::consume(RTState_V3_10__5_4& state)
+{
+  return updateState(state);
+}
 
 void ActionServer::onGoal(GoalHandle gh)
 {

--- a/src/ros/rt_publisher.cpp
+++ b/src/ros/rt_publisher.cpp
@@ -117,3 +117,7 @@ bool RTPublisher::consume(RTState_V3_2__3& state)
 {
   return publish(state);
 }
+bool RTPublisher::consume(RTState_V3_5__5_1& state)
+{
+  return publish(state);
+}

--- a/src/ros/rt_publisher.cpp
+++ b/src/ros/rt_publisher.cpp
@@ -121,3 +121,7 @@ bool RTPublisher::consume(RTState_V3_5__5_1& state)
 {
   return publish(state);
 }
+bool RTPublisher::consume(RTState_V3_10__5_4& state)
+{
+  return publish(state);
+}

--- a/src/ros_main.cpp
+++ b/src/ros_main.cpp
@@ -117,7 +117,6 @@ std::string getLocalIPAccessibleFromHost(std::string &host)
 int main(int argc, char **argv)
 {
   ros::init(argc, argv, "ur_driver");
-
   ProgArgs args;
   if (!parse_args(args))
   {
@@ -201,6 +200,8 @@ int main(int argc, char **argv)
   MultiConsumer<StatePacket> state_cons(state_vec);
   Pipeline<StatePacket> state_pl(state_prod, state_cons, "StatePacket", *notifier);
 
+  ros::Duration duration(3.0);
+  duration.sleep();
   LOG_INFO("Starting main loop");
 
   rt_pl.run();

--- a/src/ur/master_board.cpp
+++ b/src/ur/master_board.cpp
@@ -89,7 +89,7 @@ bool MasterBoardData_V3_2::parseWith(BinParser& bp)
   return true;
 }
 
-bool MasterBoardData_V3_10::parseWith(BinParser& bp)
+bool MasterBoardData_V3_10__5_4::parseWith(BinParser& bp)
 {
   if (!bp.checkSize<MasterBoardData_V3_2>())
     return false;
@@ -112,7 +112,7 @@ bool MasterBoardData_V3_2::consumeWith(URStatePacketConsumer& consumer)
 {
   return consumer.consume(*this);
 }
-bool MasterBoardData_V3_10::consumeWith(URStatePacketConsumer& consumer)
+bool MasterBoardData_V3_10__5_4::consumeWith(URStatePacketConsumer& consumer)
 {
   return consumer.consume(*this);
 }

--- a/src/ur/master_board.cpp
+++ b/src/ur/master_board.cpp
@@ -89,6 +89,17 @@ bool MasterBoardData_V3_2::parseWith(BinParser& bp)
   return true;
 }
 
+bool MasterBoardData_V3_10::parseWith(BinParser& bp)
+{
+  if (!bp.checkSize<MasterBoardData_V3_2>())
+    return false;
+
+  MasterBoardData_V3_2::parseWith(bp);
+  bp.parse(unknown_UR_internal);
+
+  return true;
+}
+
 bool MasterBoardData_V1_X::consumeWith(URStatePacketConsumer& consumer)
 {
   return consumer.consume(*this);
@@ -98,6 +109,10 @@ bool MasterBoardData_V3_0__1::consumeWith(URStatePacketConsumer& consumer)
   return consumer.consume(*this);
 }
 bool MasterBoardData_V3_2::consumeWith(URStatePacketConsumer& consumer)
+{
+  return consumer.consume(*this);
+}
+bool MasterBoardData_V3_10::consumeWith(URStatePacketConsumer& consumer)
 {
   return consumer.consume(*this);
 }

--- a/src/ur/rt_state.cpp
+++ b/src/ur/rt_state.cpp
@@ -99,6 +99,19 @@ bool RTState_V3_2__3::parseWith(BinParser& bp)
   return true;
 }
 
+bool RTState_V3_5__5_1::parseWith(BinParser& bp)
+{
+  if (!bp.checkSize<RTState_V3_5__5_1>())
+    return false;
+
+  RTState_V3_2__3::parseWith(bp);
+
+  bp.parse(elbow_position);
+  bp.parse(elbow_velocity);
+
+  return true;
+}
+
 bool RTState_V1_6__7::consumeWith(URRTPacketConsumer& consumer)
 {
   return consumer.consume(*this);
@@ -112,6 +125,10 @@ bool RTState_V3_0__1::consumeWith(URRTPacketConsumer& consumer)
   return consumer.consume(*this);
 }
 bool RTState_V3_2__3::consumeWith(URRTPacketConsumer& consumer)
+{
+  return consumer.consume(*this);
+}
+bool RTState_V3_5__5_1::consumeWith(URRTPacketConsumer& consumer)
 {
   return consumer.consume(*this);
 }

--- a/src/ur/rt_state.cpp
+++ b/src/ur/rt_state.cpp
@@ -112,9 +112,9 @@ bool RTState_V3_5__5_1::parseWith(BinParser& bp)
   return true;
 }
 
-bool RTState_V3_10__5_4::parseWith(BinParser&bp)
+bool RTState_V3_10__5_4::parseWith(BinParser& bp)
 {
-  if(!bp.checkSize<RTState_V3_10__5_4>())
+  if (!bp.checkSize<RTState_V3_10__5_4>())
     return false;
 
   RTState_V3_5__5_1::parseWith(bp);

--- a/src/ur/rt_state.cpp
+++ b/src/ur/rt_state.cpp
@@ -112,6 +112,18 @@ bool RTState_V3_5__5_1::parseWith(BinParser& bp)
   return true;
 }
 
+bool RTState_V3_10__5_4::parseWith(BinParser&bp)
+{
+  if(!bp.checkSize<RTState_V3_10__5_4>())
+    return false;
+
+  RTState_V3_5__5_1::parseWith(bp);
+
+  bp.parse(safety_status);
+
+  return true;
+}
+
 bool RTState_V1_6__7::consumeWith(URRTPacketConsumer& consumer)
 {
   return consumer.consume(*this);
@@ -129,6 +141,10 @@ bool RTState_V3_2__3::consumeWith(URRTPacketConsumer& consumer)
   return consumer.consume(*this);
 }
 bool RTState_V3_5__5_1::consumeWith(URRTPacketConsumer& consumer)
+{
+  return consumer.consume(*this);
+}
+bool RTState_V3_10__5_4::consumeWith(URRTPacketConsumer& consumer)
 {
   return consumer.consume(*this);
 }

--- a/tests/ur/rt_state.cpp
+++ b/tests/ur/rt_state.cpp
@@ -159,6 +159,56 @@ TEST(RTState_V3_2__3, testRandomDataParsing)
   EXPECT_TRUE(bp.empty()) << "did not consume all data";
 }
 
+TEST(RTState_V3_5__5_1, testRandomDataParsing)
+{
+  RandomDataTest rdt(1108);
+  BinParser bp = rdt.getParser(true);
+  RTState_V3_5__5_1 state;
+  EXPECT_TRUE(state.parseWith(bp)) << "parse() returned false";
+
+  ASSERT_EQ(rdt.getNext<double>(), state.time);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.q_target);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.qd_target);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.qdd_target);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.i_target);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.m_target);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.q_actual);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.qd_actual);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.i_actual);
+
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.i_control);
+  ASSERT_EQ(rdt.getNext<cartesian_coord_t>(), state.tool_vector_actual);
+  ASSERT_EQ(rdt.getNext<cartesian_coord_t>(), state.tcp_speed_actual);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.tcp_force);
+  ASSERT_EQ(rdt.getNext<cartesian_coord_t>(), state.tool_vector_target);
+  ASSERT_EQ(rdt.getNext<cartesian_coord_t>(), state.tcp_speed_target);
+
+  ASSERT_EQ(rdt.getNext<uint64_t>(), state.digital_inputs);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.motor_temperatures);
+  ASSERT_EQ(rdt.getNext<double>(), state.controller_time);
+  rdt.skip(sizeof(double));  // skip unused value
+  ASSERT_EQ(rdt.getNext<double>(), state.robot_mode);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.joint_modes);
+  ASSERT_EQ(rdt.getNext<double>(), state.safety_mode);
+  rdt.skip(sizeof(double) * 6);
+  ASSERT_EQ(rdt.getNext<double3_t>(), state.tool_accelerometer_values);
+  rdt.skip(sizeof(double) * 6);
+  ASSERT_EQ(rdt.getNext<double>(), state.speed_scaling);
+  ASSERT_EQ(rdt.getNext<double>(), state.linear_momentum_norm);
+  rdt.skip(sizeof(double) * 2);
+  ASSERT_EQ(rdt.getNext<double>(), state.v_main);
+  ASSERT_EQ(rdt.getNext<double>(), state.v_robot);
+  ASSERT_EQ(rdt.getNext<double>(), state.i_robot);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.v_actual);
+  ASSERT_EQ(rdt.getNext<uint64_t>(), state.digital_outputs);
+  ASSERT_EQ(rdt.getNext<double>(), state.program_state);
+
+  ASSERT_EQ(rdt.getNext<double3_t>(), state.elbow_position);
+  ASSERT_EQ(rdt.getNext<double3_t>(), state.elbow_velocity);
+
+  EXPECT_TRUE(bp.empty()) << "did not consume all data";
+}
+
 TEST(RTState_V1_6__7, testTooSmallBuffer)
 {
   RandomDataTest rdt(10);
@@ -188,5 +238,13 @@ TEST(RTState_V3_2__3, testTooSmallBuffer)
   RandomDataTest rdt(10);
   BinParser bp = rdt.getParser(true);
   RTState_V3_2__3 state;
+  EXPECT_FALSE(state.parseWith(bp)) << "parse() should fail when buffer not big enough";
+}
+
+TEST(RTState_V3_5__5_1, testTooSmallBuffer)
+{
+  RandomDataTest rdt(10);
+  BinParser bp = rdt.getParser(true);
+  RTState_V3_5__5_1 state;
   EXPECT_FALSE(state.parseWith(bp)) << "parse() should fail when buffer not big enough";
 }

--- a/tests/ur/rt_state.cpp
+++ b/tests/ur/rt_state.cpp
@@ -209,6 +209,58 @@ TEST(RTState_V3_5__5_1, testRandomDataParsing)
   EXPECT_TRUE(bp.empty()) << "did not consume all data";
 }
 
+TEST(RTState_V3_10__5_4, testRandomDataParsing)
+{
+  RandomDataTest rdt(1116);
+  BinParser bp = rdt.getParser(true);
+  RTState_V3_10__5_4 state;
+  EXPECT_TRUE(state.parseWith(bp)) << "parse() returned false";
+
+  ASSERT_EQ(rdt.getNext<double>(), state.time);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.q_target);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.qd_target);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.qdd_target);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.i_target);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.m_target);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.q_actual);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.qd_actual);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.i_actual);
+
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.i_control);
+  ASSERT_EQ(rdt.getNext<cartesian_coord_t>(), state.tool_vector_actual);
+  ASSERT_EQ(rdt.getNext<cartesian_coord_t>(), state.tcp_speed_actual);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.tcp_force);
+  ASSERT_EQ(rdt.getNext<cartesian_coord_t>(), state.tool_vector_target);
+  ASSERT_EQ(rdt.getNext<cartesian_coord_t>(), state.tcp_speed_target);
+
+  ASSERT_EQ(rdt.getNext<uint64_t>(), state.digital_inputs);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.motor_temperatures);
+  ASSERT_EQ(rdt.getNext<double>(), state.controller_time);
+  rdt.skip(sizeof(double));  // skip unused value
+  ASSERT_EQ(rdt.getNext<double>(), state.robot_mode);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.joint_modes);
+  ASSERT_EQ(rdt.getNext<double>(), state.safety_mode);
+  rdt.skip(sizeof(double) * 6);
+  ASSERT_EQ(rdt.getNext<double3_t>(), state.tool_accelerometer_values);
+  rdt.skip(sizeof(double) * 6);
+  ASSERT_EQ(rdt.getNext<double>(), state.speed_scaling);
+  ASSERT_EQ(rdt.getNext<double>(), state.linear_momentum_norm);
+  rdt.skip(sizeof(double) * 2);
+  ASSERT_EQ(rdt.getNext<double>(), state.v_main);
+  ASSERT_EQ(rdt.getNext<double>(), state.v_robot);
+  ASSERT_EQ(rdt.getNext<double>(), state.i_robot);
+  ASSERT_DOUBLE_ARRAY_EQ(rdt.getNext<double>(), state.v_actual);
+  ASSERT_EQ(rdt.getNext<uint64_t>(), state.digital_outputs);
+  ASSERT_EQ(rdt.getNext<double>(), state.program_state);
+
+  ASSERT_EQ(rdt.getNext<double3_t>(), state.elbow_position);
+  ASSERT_EQ(rdt.getNext<double3_t>(), state.elbow_velocity);
+
+  ASSERT_EQ(rdt.getNext<double>(),state.safety_status);
+
+  EXPECT_TRUE(bp.empty()) << "did not consume all data";
+}
+
 TEST(RTState_V1_6__7, testTooSmallBuffer)
 {
   RandomDataTest rdt(10);
@@ -246,5 +298,13 @@ TEST(RTState_V3_5__5_1, testTooSmallBuffer)
   RandomDataTest rdt(10);
   BinParser bp = rdt.getParser(true);
   RTState_V3_5__5_1 state;
+  EXPECT_FALSE(state.parseWith(bp)) << "parse() should fail when buffer not big enough";
+}
+
+TEST(RTState_V3_10__5_4, testTooSmallBuffer)
+{
+  RandomDataTest rdt(10);
+  BinParser bp = rdt.getParser(true);
+  RTState_V3_10__5_4 state;
   EXPECT_FALSE(state.parseWith(bp)) << "parse() should fail when buffer not big enough";
 }

--- a/tests/ur/rt_state.cpp
+++ b/tests/ur/rt_state.cpp
@@ -256,7 +256,7 @@ TEST(RTState_V3_10__5_4, testRandomDataParsing)
   ASSERT_EQ(rdt.getNext<double3_t>(), state.elbow_position);
   ASSERT_EQ(rdt.getNext<double3_t>(), state.elbow_velocity);
 
-  ASSERT_EQ(rdt.getNext<double>(),state.safety_status);
+  ASSERT_EQ(rdt.getNext<double>(), state.safety_status);
 
   EXPECT_TRUE(bp.empty()) << "did not consume all data";
 }


### PR DESCRIPTION
Modified ur_modern_driver to be compatible with UR e-series robots running 5.4 or 3.10 software. This driver should be backwards compatible with previous software versions. The README has been updated to reference e-series launch files and potential solutions to problems with excessive joint movements in planning and overshooting in execution. 

This has been successfully tested on a UR10e robot running 5.4.2.76197 software with both kinetic and melodic ROS installs. This works with ros_industrial's universal_robot. 

Should fix issues #316 and #136 and expands on #216 . 