### PR TITLE
fix default servoj_lookahead_time

### DIFF
--- a/launch/ur_common.launch
+++ b/launch/ur_common.launch
@@ -21,7 +21,7 @@
   <arg name="servoj_time_waiting" default="0.001" />
   <arg name="max_waiting_time" default="2.0" />
   <arg name="servoj_gain" default="100." />
-  <arg name="servoj_lookahead_time" default="1." />
+  <arg name="servoj_lookahead_time" default=".1" />
   <arg name="max_joint_difference" default="0.01" />
   <arg name="base_frame" default="$(arg prefix)base" />
   <arg name="tool_frame" default="$(arg prefix)tool0_controller" />


### PR DESCRIPTION
I know @gavanderhoorn claims this repository is obsolete for political reasons, but I believe this two-byte change should still be merged. :)

The documented range (https://www.universal-robots.com/download/) of this parameter for the `servoj` command is [0.03;0.2], so the default 1.0 is an extreme value way out of the actual range.

For us, running on a UR5 CB, this lead to eef errors of +-.5cm in the final goal location.
Reducing the value to the rough center of the range produces much more reasonable results below 1mm eef error.